### PR TITLE
Show temporal document title while detail pages are loading

### DIFF
--- a/src/Recollections.Blazor.UI/Entries/Pages/BeingDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/BeingDetail.razor
@@ -1,9 +1,10 @@
 ﻿@page "/beings/{BeingId}"
 @inherits UserStateComponentBase
 
+<DocumentTitle Value="@(Model?.Name ?? "Being...")" />
+
 @if (Model != null)
 {
-    <DocumentTitle Value="@Model.Name" />
 
     <CascadingValue Value="@Model">
         <PermissionContainer State="@Permissions">

--- a/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor
@@ -1,9 +1,10 @@
 ﻿@page "/entries/{EntryId}"
 @inherits UserStateComponentBase
 
+<DocumentTitle Value="@(Model?.Title ?? "Entry...")" />
+
 @if (Model != null)
 {
-    <DocumentTitle Value="@Model.Title" />
 
     <CascadingValue Value="@Model">
         <PermissionContainer State="@Permissions">

--- a/src/Recollections.Blazor.UI/Entries/Pages/ImageDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/ImageDetail.razor
@@ -1,9 +1,10 @@
 ﻿@page "/entries/{EntryId}/images/{ImageId}"
 @inherits UserStateComponentBase
 
+<DocumentTitle Value="@(Model?.Name ?? "Image...")" />
+
 @if (Model != null)
 {
-    <DocumentTitle Value="@Model.Name" />
 
     <PermissionContainer State="@Permissions">
         <ActionMenu>

--- a/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor
@@ -1,9 +1,10 @@
 ﻿@page "/stories/{StoryId}"
 @inherits UserStateComponentBase
 
+<DocumentTitle Value="@(Model?.Title ?? "Story...")" />
+
 @if (Model != null)
 {
-    <DocumentTitle Value="@Model.Title" />
 
     <CascadingValue Value="@Model">
         <PermissionContainer State="@Permissions">

--- a/src/Recollections.Blazor.UI/Entries/Pages/VideoDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/VideoDetail.razor
@@ -1,9 +1,10 @@
 ﻿@page "/entries/{EntryId}/videos/{VideoId}"
 @inherits UserStateComponentBase
 
+<DocumentTitle Value="@(Model?.Name ?? "Video...")" />
+
 @if (Model != null)
 {
-    <DocumentTitle Value="@Model.Name" />
 
     <PermissionContainer State="@Permissions">
         <ActionMenu>


### PR DESCRIPTION
Detail pages (Entry, Story, Being, Image, Video) wrap all content inside `@if (Model != null)`, including the `<DocumentTitle>` component. While data is loading, the previous page's title stays in the browser tab, making it unclear which page the user navigated to.

This moves `<DocumentTitle>` outside the null-check on each detail page, using a null-coalescing fallback so a placeholder title appears immediately on navigation:

- **EntryDetail** → "Entry..." while loading, then the actual entry title
- **StoryDetail** → "Story..." while loading, then the actual story title
- **BeingDetail** → "Being..." while loading, then the actual being name
- **ImageDetail** → "Image..." while loading, then the actual image name
- **VideoDetail** → "Video..." while loading, then the actual video name

Profile.razor already handled this correctly (`@(Owner?.Name ?? UserId)`) so no change was needed there.

Fixes #408