### PR TITLE
Fix InlineLink showing pen icon on hover without OnClick handler

### DIFF
--- a/src/Recollections.Blazor.Components/Components/Editors/InlineLink.razor.cs
+++ b/src/Recollections.Blazor.Components/Components/Editors/InlineLink.razor.cs
@@ -28,7 +28,7 @@ namespace Neptuo.Recollections.Components.Editors
         [Parameter]
         public RenderFragment<string> ValueContent { get; set; } = (value) => (builder) => builder.AddContent(0, value);
 
-        protected override bool IsEditable => IsClickable ?? base.IsEditable;
+        protected override bool IsEditable => IsClickable ?? (OnClick.HasDelegate && base.IsEditable);
 
         protected async override Task OnEditAsync()
         {


### PR DESCRIPTION
## Motivation

`InlineLink` displays a pen icon on hover even when it has no `OnClick` handler, making it appear editable/clickable when it's actually read-only. This is visible on the video detail page where the duration (`stopwatch` icon) incorrectly swaps to a pen on hover.

Fixes #413

## Approach

Updated the `IsEditable` override in `InlineLink` to also check `OnClick.HasDelegate` when `IsClickable` is not explicitly set:

```csharp
// Before
protected override bool IsEditable => IsClickable ?? base.IsEditable;

// After
protected override bool IsEditable => IsClickable ?? (OnClick.HasDelegate && base.IsEditable);
```

This means:
- If `IsClickable` is explicitly set — no behavior change
- Otherwise, the link is editable **only if** `OnClick` has a handler AND the base class allows editing
- An `InlineLink` with no `OnClick` (like video duration in `VideoDetail.razor`) will no longer show the `inline-editable` CSS class, so no pen icon on hover