### PR TITLE
Fix service worker double respondWith() and consumed request errors

### DIFF
--- a/src/Recollections.Blazor.UI/wwwroot/service-worker.js
+++ b/src/Recollections.Blazor.UI/wwwroot/service-worker.js
@@ -10,7 +10,8 @@ self.addEventListener('message', onMessage);
 function onFetch(event) {
     const response = shareTargetHandler(event);
     if (response) {
-        return response;
+        event.respondWith(response);
+        return;
     }
 }
 

--- a/src/Recollections.Blazor.UI/wwwroot/share-target.js
+++ b/src/Recollections.Blazor.UI/wwwroot/share-target.js
@@ -1,7 +1,7 @@
 function shareTargetHandler(event) {
     const isRootPost = event.request.method === 'POST' && event.request.mode === 'navigate';
     if (isRootPost) {
-        return event.respondWith((async () => {
+        return (async () => {
             const formData = await event.request.formData();
             const files = formData.getAll("allfiles");
             await storeFiles(files, null, null, null, null);
@@ -12,7 +12,7 @@ function shareTargetHandler(event) {
             } else {
                 return Response.redirect('/', 303);
             }
-        })());
+        })();
     }
 
     return null;


### PR DESCRIPTION
## Problem

Two errors occur in the service worker (#416):

1. `TypeError: Failed to execute 'fetch' on 'WorkerGlobalScope': Cannot construct a Request with a Request object that has already been used.`
2. `InvalidStateError: Failed to execute 'respondWith' on 'FetchEvent': respondWith() was already called.`

## Root Cause

In `share-target.js`, `shareTargetHandler()` called `event.respondWith()` directly and returned its result (`undefined`). This caused two problems in the published service worker:

1. **Double `respondWith()`**: The published service worker wraps `onFetch(event)` in `event.respondWith(onFetch(event))`. When a POST navigate request comes in, `shareTargetHandler` calls `respondWith()` first, then the outer listener calls it again.

2. **Request body consumed**: Since `shareTargetHandler` returned `undefined` (falsy), `onFetch` didn't return early. It fell through to `fetch(event.request)`, but the async IIFE had already called `event.request.formData()`, marking the body as disturbed.

## Fix

Move `event.respondWith()` out of `shareTargetHandler()` so it only returns a Response promise. Each service worker file handles `respondWith` at its own level:

- **`share-target.js`**: Returns the async response promise directly (no `respondWith` call)
- **`service-worker.js`** (dev): Calls `event.respondWith(response)` explicitly when `shareTargetHandler` returns a response
- **`service-worker.published.js`**: No changes needed — the existing `event.respondWith(onFetch(event))` pattern already wraps the returned response correctly

Fixes #416