### PR TITLE
Fix PWA service worker publish issues

### DIFF
--- a/src/Recollections.Blazor.UI/wwwroot/service-worker.published.js
+++ b/src/Recollections.Blazor.UI/wwwroot/service-worker.published.js
@@ -3,9 +3,11 @@
 
 self.importScripts('./service-worker-assets.js');
 
-const shareTargetAsset = self.assetsManifest.assets.find(a => a.url.startsWith('share-target') && a.url.endsWith('.js'));
+const shareTargetAsset = self.assetsManifest.assets.find(a => /^share-target(\.[a-z0-9]+)?\.js$/.test(a.url));
 if (shareTargetAsset) {
     self.importScripts('./' + shareTargetAsset.url);
+} else {
+    function shareTargetHandler() { return null; }
 }
 
 const cacheNamePrefix = 'offline-cache-';


### PR DESCRIPTION
Fixes #404

Two changes in `service-worker.published.js`:

1. **Remove integrity hash check** from asset caching — GitHub Pages serves pre-compressed files with different hashes than the manifest, causing SRI failures during service worker install. Cache versioning via `assetsManifest.version` already handles invalidation.

2. **Resolve share-target.js URL from manifest** — Asset fingerprinting renames `share-target.js` to e.g. `share-target.mnl1nis5pf.js`, but `importScripts('./share-target.js')` used the original name, causing a 404. The manifest lookup runs at top-level (during initial script evaluation), where `importScripts` is allowed per spec.