### PR TITLE
Make entry story and beings direct links for anonymous users

### DIFF
--- a/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor
@@ -37,9 +37,9 @@
                     else if (HasStory)
                     {
                         <div class="inline-editor inline-link inline-editor-viewmode">
-                            <a class="inline-editor-value d-inline-block py-1" href="@Navigator.UrlStoryDetail(Story.StoryId)">
+                            <a class="inline-editor-value d-inline-block cursor-pointer py-1" href="@Navigator.UrlStoryDetail(Story.StoryId)">
                                 <Icon Identifier="book" />
-                                <span class="ms-1 inline-editor-content">@StoryTitle</span>
+                                <span class="inline-editor-content">@StoryTitle</span>
                             </a>
                         </div>
                     }
@@ -55,14 +55,14 @@
                         <div class="inline-editor inline-link inline-editor-viewmode">
                             <span class="inline-editor-value d-inline-block py-1">
                                 <Icon Identifier="user-friends" />
-                                <span class="ms-1 inline-editor-content">
+                                <span class="inline-editor-content">
                                     @for (int i = 0; i < Beings.Count; i++)
                                     {
                                         if (i > 0)
                                         {
                                             <text>, </text>
                                         }
-                                        <a href="@Navigator.UrlBeingDetail(Beings[i].Id)">@Beings[i].Name</a>
+                                        <a class="cursor-pointer" href="@Navigator.UrlBeingDetail(Beings[i].Id)">@Beings[i].Name</a>
                                     }
                                 </span>
                             </span>

--- a/src/Recollections.Blazor.UI/wwwroot/css/site.css
+++ b/src/Recollections.Blazor.UI/wwwroot/css/site.css
@@ -26026,4 +26026,4 @@ video.pswp__video {
 .version {
   color: #aaaaaa;
 }
-/*# sourceMappingURL=/Users/marekfisera/.copilot/worktrees/Recollections/maraf/issue-402-add-visual-glyph-to-distinguish-image-an-399b7e/src/Recollections.Blazor.UI/wwwroot/css/site.css.map */
+/*# sourceMappingURL=/Users/marekfisera/.copilot/worktrees/Recollections/maraf/issue-400-entry-story-and-beings-should-be-direct-078c91/src/Recollections.Blazor.UI/wwwroot/css/site.css.map */


### PR DESCRIPTION
When anonymous users open a shared entry, the Story and Beings sections display text but are not clickable. This is because the `InlineLink` component checks `FormState.IsEditable` before handling clicks, and for read-only users `IsEditable` is `false` — so clicking does nothing.

### Approach

Instead of modifying the shared `InlineLink` component, the `EntryDetail.razor` template now conditionally renders the story and beings sections based on permissions:

- **Editable users (owners):** Keep the existing `InlineLink` with picker behavior — clicking opens `StoryPicker` / `BeingPicker` to change the association
- **Read-only users (anonymous or shared):** Render proper HTML `<a href>` links navigating directly to the detail pages:
  - **Story** → `/stories/{storyId}` (single link)
  - **Beings** → each being rendered as an individual `/beings/{beingId}` link, comma-separated

This gives anonymous users standard browser links with hover URL preview, middle-click-to-open-in-new-tab support, etc. When no story or beings are set, the section is simply hidden for read-only users (the "No story..." / "No beings..." placeholder is only useful for editors).

Fixes #400