### PR TITLE
Fix map type dialog showing stale selection after change

### DIFF
--- a/src/Recollections.Blazor.Components/Components/Map.razor.cs
+++ b/src/Recollections.Blazor.Components/Components/Map.razor.cs
@@ -40,6 +40,7 @@ namespace Neptuo.Recollections.Components
         protected string SearchQuery { get; set; }
         protected List<MapSearchModel> SearchResults { get; } = [];
         protected bool HasSearchResultsChanged { get; set;}
+        protected bool HasTileTypeChanged { get; set; }
         protected Modal TileTypeModal { get; set; }
         protected string TileType { get; set; }
 
@@ -77,8 +78,9 @@ namespace Neptuo.Recollections.Components
 
         protected override bool ShouldRender()
         {
-            var result = Interop.ShouldRender() || HasSearchResultsChanged;
+            var result = Interop.ShouldRender() || HasSearchResultsChanged || HasTileTypeChanged;
             HasSearchResultsChanged = false;
+            HasTileTypeChanged = false;
             Log.Debug($"ShouldRender: {result}");
             return result;
         }
@@ -151,6 +153,7 @@ namespace Neptuo.Recollections.Components
         protected async Task SelectTypeAsync(string type)
         {
             TileType = type;
+            HasTileTypeChanged = true;
             await Interop.RedrawAsync();
             await Service.SetTypeAsync(type);
             TileTypeModal.Hide();


### PR DESCRIPTION
When a user changes the map type (Basic/Outdoor/Winter) in the modal dialog, the new type is correctly applied to the map tiles. However, if the dialog is reopened without a page reload, the previously selected button still appears highlighted instead of the new one.

### Cause

The `Map` component overrides `ShouldRender()` to optimize re-renders, but it only tracked marker and map-position changes. After `SelectTypeAsync` updated `TileType`, the component skipped re-rendering, so the button CSS classes (`btn-primary` vs `btn-secondary`) in the modal remained stale.

### Fix

Added a `HasTileTypeChanged` flag — following the existing `HasSearchResultsChanged` pattern — that is set in `SelectTypeAsync` and checked/reset in `ShouldRender()`. This ensures the component re-renders after a tile type change so the modal reflects the current selection.