### PR TITLE
Add GitHub Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,7 @@
 
 ## Running the Application
 
+- Restore .NET tools with `dotnet tool restore` before building. This installs the `excubo.webcompiler` tool needed to compile SCSS files.
 - Run the application with `dotnet run ./src/AppHost.cs`.
 
 ## Pull Request Reviews


### PR DESCRIPTION
Adds `.github/copilot-instructions.md` to guide Copilot when working in this repository. The instructions cover:

- **Code quality** — always deduplicate logic by extracting to a service or shared method/class
- **Running the application** — restore .NET tools (`dotnet tool restore` for `excubo.webcompiler` SCSS compilation) and run with `dotnet run ./src/AppHost.cs`
- **PR reviews** — always reply to review comments when applying feedback