### PR TITLE
Optimize StoryListMapper to avoid N+1 queries

### DIFF
--- a/src/Recollections.Api/Entries/Services/StoryListMapper.cs
+++ b/src/Recollections.Api/Entries/Services/StoryListMapper.cs
@@ -13,34 +13,64 @@ public class StoryListMapper(DataContext dataContext, IUserNameProvider userName
 {
     public async Task<List<StoryListModel>> MapAsync(List<Story> stories, string userId, ConnectedUsersModel connectedUsers)
     {
-        List<StoryListModel> models = new();
+        if (stories.Count == 0)
+            return [];
+
+        var storyIds = stories
+            .Select(s => s.Id)
+            .ToArray();
+
+        var chapterCounts = await dataContext.Stories
+            .Where(s => storyIds.Contains(s.Id))
+            .Select(s => new
+            {
+                s.Id,
+                Chapters = s.Chapters.Count
+            })
+            .ToDictionaryAsync(s => s.Id, s => s.Chapters);
+
+        var entryStats = await shareStatus
+            .OwnedByOrExplicitlySharedWithUser(dataContext, dataContext.Entries, [userId, ShareStatusService.PublicUserId], connectedUsers)
+            .Where(e =>
+                (e.Story != null && storyIds.Contains(e.Story.Id))
+                || (e.Chapter != null && storyIds.Contains(e.Chapter.Story.Id))
+            )
+            .Select(e => new
+            {
+                StoryId = e.Story != null ? e.Story.Id : e.Chapter.Story.Id,
+                e.When
+            })
+            .GroupBy(e => e.StoryId)
+            .Select(g => new
+            {
+                StoryId = g.Key,
+                Entries = g.Count(),
+                MinDate = g.Min(e => e.When),
+                MaxDate = g.Max(e => e.When)
+            })
+            .ToDictionaryAsync(s => s.StoryId);
+
+        List<StoryListModel> models = new(stories.Count);
         foreach (var story in stories)
         {
-            var model = new StoryListModel();
-            models.Add(model);
-
-            model.Id = story.Id;
-            model.UserId = story.UserId;
-            model.Title = story.Title;
-
-            int chapters = await dataContext.Stories
-                .Where(s => s.Id == story.Id)
-                .SelectMany(s => s.Chapters)
-                .CountAsync();
-
-            var entries = await shareStatus.OwnedByOrExplicitlySharedWithUser(dataContext, dataContext.Entries, [userId, ShareStatusService.PublicUserId], connectedUsers)
-                .Where(e => e.Story.Id == story.Id || e.Chapter.Story.Id == story.Id)
-                .Select(e => e.When)
-                .ToListAsync();
-
-            model.Chapters = chapters;
-            model.Entries = entries.Count;
-
-            if (entries.Count > 0)
+            var model = new StoryListModel()
             {
-                model.MinDate = entries.Min();
-                model.MaxDate = entries.Max();
+                Id = story.Id,
+                UserId = story.UserId,
+                Title = story.Title
+            };
+
+            if (chapterCounts.TryGetValue(story.Id, out var chapters))
+                model.Chapters = chapters;
+
+            if (entryStats.TryGetValue(story.Id, out var entryStat))
+            {
+                model.Entries = entryStat.Entries;
+                model.MinDate = entryStat.MinDate;
+                model.MaxDate = entryStat.MaxDate;
             }
+
+            models.Add(model);
         }
 
         var userNamesList = await userNames.GetUserNamesAsync(models.Select(e => e.UserId).ToArray());


### PR DESCRIPTION
Closes #453

`StoryListMapper.MapAsync` still queried chapter and entry data once per story after #449, which kept the story list path in an N+1 pattern. This change switches that work to grouped, set-based aggregates so the endpoints keep the same output with far fewer database round-trips.

### What changed

- load chapter counts for the requested stories in a single query
- load accessible entry counts plus min/max dates in a single grouped query keyed by story ID
- preserve the existing username lookup and final story ordering

### Verification

- compared the new mapper against the previous implementation with a temporary SQLite-backed equivalence harness covering direct story entries, chapter-backed entries, shared/public visibility, and stories with no entries