### PR TITLE
Ignore own entries in timeline new-entry count

### DIFF
--- a/src/Recollections.Api/Entries/Controllers/TimelineController.cs
+++ b/src/Recollections.Api/Entries/Controllers/TimelineController.cs
@@ -79,7 +79,9 @@ namespace Neptuo.Recollections.Entries.Controllers
                     db.Entries.Where(e => e.Created > lastVisitAt),
                     userId,
                     connectedUsers
-                ).CountAsync();
+                )
+                .Where(e => e.UserId != userId)
+                .CountAsync();
             }
 
             var now = DateTime.Now;


### PR DESCRIPTION
This fixes a confusing timeline badge case where creating a new entry and returning to the timeline could immediately show `1 new entry` for the entry the current user just created.

The change keeps the existing timeline visibility rules in place, but excludes entries owned by the current user when calculating the `new since your last visit` count. Timeline contents and last-visit tracking are otherwise unchanged.