### PR TITLE
Prepare v0.18.0 release notes and dev version defaults

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,10 @@
 - Run the application with `dotnet run ./src/AppHost.cs`.
 - If the default ports are already in use, invoke the `run-custom-ports` skill to run the application on a different set of ports.
 
+## Release Notes
+
+- When asked to prepare release notes, invoke the `release-notes-writer` skill and update `src/Recollections.Blazor.UI/wwwroot/release-notes.html` from the matching GitHub milestone.
+
 ## Pull Request Reviews
 
 - Always reply to review comments when applying feedback on a PR.

--- a/.github/skills/release-notes-writer/SKILL.md
+++ b/.github/skills/release-notes-writer/SKILL.md
@@ -73,10 +73,10 @@ git --no-pager show <commit>:src/Recollections.Blazor.UI/wwwroot/release-notes.h
 
 ### 3. Collect Delivered Work
 
-- List all milestone items with:
+- List all delivered milestone items with:
 
 ```bash
-gh api 'repos/neptuo/Recollections/issues?milestone={number}&state=all&per_page=100'
+gh api --paginate 'repos/neptuo/Recollections/issues?milestone={number}&state=closed&per_page=100'
 ```
 
 - Read issue or PR bodies for items whose titles are ambiguous.

--- a/.github/skills/release-notes-writer/SKILL.md
+++ b/.github/skills/release-notes-writer/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: release-notes-writer
+description: >
+  Prepare Recollections release notes by finding the matching GitHub milestone,
+  extracting the delivered user-facing changes, and updating
+  `src/Recollections.Blazor.UI/wwwroot/release-notes.html`. USE FOR: "prepare
+  release notes", "update release-notes.html", "write release notes for v0.18.0",
+  summarizing a milestone, release summary from GitHub issues or PRs. DO NOT
+  USE FOR: exhaustive changelogs, CI/test summaries, deployment notes, or API
+  release notes that do not update the Blazor UI release notes page. INVOKES:
+  gh CLI and git history.
+---
+
+# Release Notes Writer
+
+Use this skill to update the Blazor UI release notes page for a specific
+Recollections release.
+
+## Target File
+
+Update only:
+
+- `src/Recollections.Blazor.UI/wwwroot/release-notes.html`
+
+Keep the existing structure:
+
+```html
+<h3>New features</h3>
+<ul>
+    <li>...</li>
+</ul>
+
+<div class="row">
+    <div class="col-12 col-md-auto">
+        <a target="_blank" href="https://github.com/neptuo/Recollections/milestone/{number}?closed=1" class="btn bg-light-subtle w-100">
+            <span class="fab fa-github"></span>
+            See details on GitHub
+        </a>
+    </div>
+</div>
+```
+
+## Process
+
+### 1. Find the Release Milestone
+
+- Read the user-requested version, for example `v0.18.0`.
+- Find the matching GitHub milestone with:
+
+```bash
+gh api repos/neptuo/Recollections/milestones --paginate --jq '.[] | [.number, .title, .state] | @tsv'
+```
+
+- If the version does not map cleanly to a milestone title, ask the user before
+  editing.
+
+### 2. Learn the Repo's Release-Note Style
+
+- Read the current `release-notes.html`.
+- Inspect its recent history with:
+
+```bash
+git --no-pager log --follow --oneline -- src/Recollections.Blazor.UI/wwwroot/release-notes.html
+git --no-pager show <commit>:src/Recollections.Blazor.UI/wwwroot/release-notes.html
+```
+
+- Match the existing style:
+  - one `New features` section
+  - concise user-facing bullet fragments
+  - no trailing periods
+  - no issue numbers or PR numbers in the HTML
+  - one GitHub milestone button at the end
+
+### 3. Collect Delivered Work
+
+- List all milestone items with:
+
+```bash
+gh api 'repos/neptuo/Recollections/issues?milestone={number}&state=all&per_page=100'
+```
+
+- Read issue or PR bodies for items whose titles are ambiguous.
+- Use labels and titles to separate visible product changes from internal work.
+
+### 4. Filter for User-Facing Changes
+
+Keep:
+
+- visible features
+- navigation, sharing, search, loading, and media improvements
+- map and timeline improvements
+- bug fixes users would notice
+
+Exclude:
+
+- CI, tests, deployment, publishing, screenshots, and sample data
+- refactors and internal performance work unless the improvement is visible to users
+- code-only cleanup like library swaps
+
+### 5. Write Release Bullets
+
+- Prefer 6-12 bullets, depending on scope.
+- Lead with the biggest visible features.
+- Group related small fixes into one bullet instead of mirroring each issue title.
+- Translate internal issue names into product language.
+
+Good:
+
+- `Search in Entry picker`
+- `Better loading states, faster story lists, and small UI fixes`
+
+Avoid:
+
+- `Optimize StoryListMapper to avoid N+1 query pattern`
+- `Remove jQuery`
+- `Fix publish`
+
+### 6. Update the File
+
+- Replace the existing bullet list with the new release content.
+- Update the milestone link to the matching milestone number.
+- Keep indentation and HTML structure consistent with the file history.
+
+### 7. Final Check
+
+- Make sure every bullet is user-facing.
+- Make sure the milestone link ends with `?closed=1`.
+- Make sure the page does not mention CI or tests.
+
+## Example
+
+### Example 1: Preparing a Release Page
+
+**User Request**: `Prepare release notes for v0.18.0 and update src/Recollections.Blazor.UI/wwwroot/release-notes.html`
+
+**Expected behavior**:
+
+1. Find the `v0.18.0` milestone number on GitHub.
+2. Review the history of `release-notes.html` to match prior wording.
+3. Summarize the milestone into short user-facing bullets.
+4. Update the milestone link in the HTML.
+
+## References
+
+- [Release note checklist](references/release-note-checklist.md)

--- a/.github/skills/release-notes-writer/references/release-note-checklist.md
+++ b/.github/skills/release-notes-writer/references/release-note-checklist.md
@@ -50,7 +50,7 @@ Examples:
 
 ```bash
 gh api repos/neptuo/Recollections/milestones --paginate --jq '.[] | [.number, .title, .state] | @tsv'
-gh api 'repos/neptuo/Recollections/issues?milestone={number}&state=all&per_page=100'
+gh api --paginate 'repos/neptuo/Recollections/issues?milestone={number}&state=closed&per_page=100'
 git --no-pager log --follow --oneline -- src/Recollections.Blazor.UI/wwwroot/release-notes.html
 git --no-pager show <commit>:src/Recollections.Blazor.UI/wwwroot/release-notes.html
 ```

--- a/.github/skills/release-notes-writer/references/release-note-checklist.md
+++ b/.github/skills/release-notes-writer/references/release-note-checklist.md
@@ -1,0 +1,56 @@
+# Release Note Checklist
+
+Use this checklist after collecting milestone items and before editing
+`src/Recollections.Blazor.UI/wwwroot/release-notes.html`.
+
+## Keep the Existing Format
+
+- One `<h3>New features</h3>` heading.
+- One `<ul>` with short bullet fragments.
+- No trailing periods.
+- No issue numbers, PR numbers, or commit SHAs in the HTML.
+- One GitHub button pointing to the matching milestone with `?closed=1`.
+
+## Prefer Product Language
+
+Write what users notice, not how the code changed.
+
+Good:
+
+- `Map can highlight visited countries`
+- `Direct links to Story and Beings from shared entries`
+- `Better loading states, faster story lists, and small UI fixes`
+
+Avoid:
+
+- `Optimize StoryListMapper to avoid N+1 query pattern`
+- `Remove jQuery`
+- `Fix publish`
+
+## What to Exclude
+
+Do not mention:
+
+- CI or tests
+- deployment and publishing changes
+- screenshots and sample data work
+- internal refactors unless users directly feel the effect
+
+## Group Small Changes
+
+Do not mirror GitHub item titles one by one when several items describe the same
+surface area.
+
+Examples:
+
+- Several loading and polish items -> `Better loading states, faster story lists, and small UI fixes`
+- Multiple media presentation tweaks -> `Video size warning and better fit for tall media in detail`
+
+## Milestone Review Commands
+
+```bash
+gh api repos/neptuo/Recollections/milestones --paginate --jq '.[] | [.number, .title, .state] | @tsv'
+gh api 'repos/neptuo/Recollections/issues?milestone={number}&state=all&per_page=100'
+git --no-pager log --follow --oneline -- src/Recollections.Blazor.UI/wwwroot/release-notes.html
+git --no-pager show <commit>:src/Recollections.Blazor.UI/wwwroot/release-notes.html
+```

--- a/src/Recollections.Api/Recollections.Api.csproj
+++ b/src/Recollections.Api/Recollections.Api.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>Neptuo.Recollections</RootNamespace>
-    <VersionPrefix>0.17.1</VersionPrefix>
+    <VersionPrefix>0.0.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Recollections.Blazor.UI/Recollections.Blazor.UI.csproj
+++ b/src/Recollections.Blazor.UI/Recollections.Blazor.UI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Neptuo.Recollections</RootNamespace>
-    <VersionPrefix>0.17.0</VersionPrefix>
+    <VersionPrefix>0.0.0</VersionPrefix>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
 	  <InvariantGlobalization>true</InvariantGlobalization>
     <PublishDomain>recollections.app</PublishDomain>

--- a/src/Recollections.Blazor.UI/wwwroot/release-notes.html
+++ b/src/Recollections.Blazor.UI/wwwroot/release-notes.html
@@ -1,20 +1,22 @@
 <h3>New features</h3>
 <ul>
-    <li>Consolidated edit menus to a single floating button</li>
-    <li>Restore map position when returning from entry detail</li>
-    <li>File upload will continue in background when user leaves entry</li>
-    <li>More files can be added to queue while uploading</li>
-    <li>Files can be shared to Recollections from other applications</li>
-    <li>Preview of all images in Story</li>
-    <li>Entry and Story maps are fullscreen</li>
-    <li>UI tweaks, especially on mobile</li>
-    <li>Filter stories in Story picker</li>
-    <li>Dark theme for markdown editor</li>
+    <li>First few images visible directly in timeline</li>
+    <li>"On this day" page and banner for memories from previous years</li>
+    <li>Banner with count of new entries since last visit</li>
+    <li>Improved Being detail with related stories, map pins, and timeline layout</li>
+    <li>Map can highlight visited countries</li>
+    <li>Search in Entry picker</li>
+    <li>Direct links to Story and Beings from shared entries</li>
+    <li>Clickable links in markdown text</li>
+    <li>Image and video glyphs in thumbnails and gallery</li>
+    <li>Video size warning and better fit for tall media in detail</li>
+    <li>Restored timeline position when returning from entry detail</li>
+    <li>Better loading states, faster story lists, and small UI fixes</li>
 </ul>
 
 <div class="row">
     <div class="col-12 col-md-auto">
-        <a target="_blank" href="https://github.com/neptuo/Recollections/milestone/45?closed=1" class="btn bg-light-subtle w-100">
+        <a target="_blank" href="https://github.com/neptuo/Recollections/milestone/48?closed=1" class="btn bg-light-subtle w-100">
             <span class="fab fa-github"></span>
             See details on GitHub
         </a>

--- a/src/Recollections.Blazor.UI/wwwroot/release-notes.html
+++ b/src/Recollections.Blazor.UI/wwwroot/release-notes.html
@@ -16,7 +16,7 @@
 
 <div class="row">
     <div class="col-12 col-md-auto">
-        <a target="_blank" href="https://github.com/neptuo/Recollections/milestone/48?closed=1" class="btn bg-light-subtle w-100">
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/neptuo/Recollections/milestone/48?closed=1" class="btn bg-light-subtle w-100">
             <span class="fab fa-github"></span>
             See details on GitHub
         </a>


### PR DESCRIPTION
This prepares the next release by updating the public v0.18.0 notes from the GitHub milestone and by moving local UI/API versions back to a neutral dev value now that CI publishes the release artifacts. It also adds a repo skill so future release-note updates follow the same milestone-driven workflow.

## What changed

- refreshes `src/Recollections.Blazor.UI/wwwroot/release-notes.html` for milestone 48 with only the user-facing changes
- adds a repo-scoped `release-notes-writer` skill plus a short checklist and wires it into `.github/copilot-instructions.md`
- resets `VersionPrefix` to `0.0.0` in the API and Blazor UI projects so release versioning comes from CI instead of local project files

## Notes

- the release-note skill is intentionally biased toward milestone-driven summaries in the existing HTML style
- it explicitly excludes CI, tests, deployment notes, and other internal-only changes from the release notes page