### PR TITLE
Clear consumed timeline history state

### DIFF
--- a/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor.cs
@@ -47,6 +47,7 @@ namespace Neptuo.Recollections.Entries.Components
         private int offset;
         private Task loadAsyncFromParametersSet;
         private string scrollToEntryId;
+        private bool clearRestoredPositionAfterRender;
         private string currentGalleryEntryId;
 
         protected List<EntryListModel> Entries { get; } = [];
@@ -69,6 +70,15 @@ namespace Neptuo.Recollections.Entries.Components
             return PageHistoryState.Parse(NavigationManager.HistoryEntryState).Timeline;
         }
 
+        private void QueuePositionRestore(TimelinePosition position)
+        {
+            if (position == null)
+                return;
+
+            clearRestoredPositionAfterRender = true;
+            scrollToEntryId = position.EntryId;
+        }
+
         protected async override Task OnParametersSetAsync()
         {
             await base.OnParametersSetAsync();
@@ -81,8 +91,7 @@ namespace Neptuo.Recollections.Entries.Components
                 Log.Debug($"Got parameter Data '{Data.Count}'");
 
                 var position = FindPositionFromHistoryEntry();
-                if (position != null)
-                    scrollToEntryId = position.EntryId;
+                QueuePositionRestore(position);
             }
             else if (Entries.Count == 0)
             {
@@ -102,12 +111,24 @@ namespace Neptuo.Recollections.Entries.Components
         {
             await base.OnAfterRenderAsync(firstRender);
 
-            if (loadAsyncFromParametersSet == null && scrollToEntryId != null)
+            if (loadAsyncFromParametersSet == null && (scrollToEntryId != null || clearRestoredPositionAfterRender))
             {
                 var entryId = scrollToEntryId;
+                var shouldClearPosition = clearRestoredPositionAfterRender;
                 scrollToEntryId = null;
-                Log.Debug($"Scrolling to entry '{entryId}'");
-                await JSRuntime.InvokeVoidAsync("Timeline.ScrollToEntry", entryId);
+                clearRestoredPositionAfterRender = false;
+
+                if (!string.IsNullOrEmpty(entryId))
+                {
+                    Log.Debug($"Scrolling to entry '{entryId}'");
+                    await JSRuntime.InvokeVoidAsync("Timeline.ScrollToEntry", entryId);
+                }
+
+                if (shouldClearPosition)
+                {
+                    Log.Debug("Clearing consumed timeline position from history state");
+                    await JSRuntime.InvokeVoidAsync("Timeline.ClearPosition");
+                }
             }
         }
 
@@ -125,10 +146,12 @@ namespace Neptuo.Recollections.Entries.Components
                 if (Entries.Count == 0)
                 {
                     var position = FindPositionFromHistoryEntry();
-                    if (position != null && position.Offset > 0)
+                    if (position != null)
                     {
-                        count = position.Offset;
-                        scrollToEntryId = position.EntryId;
+                        if (position.Offset > 0)
+                            count = position.Offset;
+
+                        QueuePositionRestore(position);
                         Log.Debug($"Restoring timeline position: offset={position.Offset}, entryId={position.EntryId}");
                     }
                 }

--- a/src/Recollections.Blazor.UI/wwwroot/js/site.js
+++ b/src/Recollections.Blazor.UI/wwwroot/js/site.js
@@ -313,9 +313,57 @@ function escapeCssSelectorValue(value) {
     return stringValue.replace(/["\\]/g, "\\$&");
 }
 
+function canReplacePageHistoryState() {
+    return window.history && typeof window.history.replaceState === "function";
+}
+
+function readPageHistoryUserState() {
+    var historyState = window.history.state;
+    var userState = {};
+    var serializedUserState = historyState && typeof historyState === "object" ? historyState.userState : null;
+    if (typeof serializedUserState === "string" && serializedUserState.length > 0) {
+        try {
+            userState = JSON.parse(serializedUserState);
+        } catch {
+            userState = {};
+        }
+    }
+
+    if (userState && typeof userState === "object") {
+        if (!userState.Map && typeof userState.Latitude === "number" && typeof userState.Longitude === "number") {
+            userState = { Map: userState };
+        } else if (!userState.Timeline && typeof userState.Offset === "number" && typeof userState.EntryId === "string") {
+            userState = { Timeline: userState };
+        }
+    } else {
+        userState = {};
+    }
+
+    return {
+        historyState: historyState,
+        userState: userState
+    };
+}
+
+function updatePageHistoryUserState(update) {
+    if (!canReplacePageHistoryState() || typeof update !== "function") {
+        return;
+    }
+
+    var current = readPageHistoryUserState();
+    update(current.userState);
+
+    var nextHistoryState = current.historyState && typeof current.historyState === "object"
+        ? Object.assign({}, current.historyState)
+        : {};
+
+    nextHistoryState.userState = JSON.stringify(current.userState);
+    window.history.replaceState(nextHistoryState, "", window.location.href);
+}
+
 window.Timeline = {
     StorePosition: function (element) {
-        if (!element || !window.history || typeof window.history.replaceState !== "function") {
+        if (!element) {
             return;
         }
 
@@ -325,43 +373,22 @@ window.Timeline = {
             return;
         }
 
-        var userState = {};
-        var historyState = window.history.state;
-        var serializedUserState = historyState && typeof historyState === "object" ? historyState.userState : null;
-        if (typeof serializedUserState === "string" && serializedUserState.length > 0) {
-            try {
-                userState = JSON.parse(serializedUserState);
-            } catch {
-                userState = {};
-            }
-        }
-
-        if (userState && typeof userState === "object") {
-            if (!userState.Map && typeof userState.Latitude === "number" && typeof userState.Longitude === "number") {
-                userState = { Map: userState };
-            } else if (!userState.Timeline && typeof userState.Offset === "number" && typeof userState.EntryId === "string") {
-                userState = { Timeline: userState };
-            }
-        } else {
-            userState = {};
-        }
-
-        userState.Timeline = {
-            Offset: offset,
-            EntryId: entryId
-        };
-
-        var nextHistoryState = historyState && typeof historyState === "object"
-            ? Object.assign({}, historyState)
-            : {};
-
-        nextHistoryState.userState = JSON.stringify(userState);
-        window.history.replaceState(nextHistoryState, "", window.location.href);
+        updatePageHistoryUserState(function (userState) {
+            userState.Timeline = {
+                Offset: offset,
+                EntryId: entryId
+            };
+        });
     },
     StorePositionOnKeyDown: function (element, event) {
         if (event && (event.key === "Enter" || event.key === " ")) {
             window.Timeline.StorePosition(element);
         }
+    },
+    ClearPosition: function () {
+        updatePageHistoryUserState(function (userState) {
+            delete userState.Timeline;
+        });
     },
     ScrollToEntry: function (entryId) {
         var escapedEntryId = escapeCssSelectorValue(entryId);


### PR DESCRIPTION
Fixes #469.

Returning to the timeline from an entry detail should restore the selected entry once. The problem was that the `Timeline` payload stayed on the browser history entry after it was consumed, so later returns from unrelated pages could scroll back to stale state.

This change makes timeline restoration single-use:
- queue the restore on the Blazor side and clear the consumed timeline position after render
- reuse a shared history-state update path in `site.js` so storing and clearing timeline state preserves any unrelated history payloads

## Validation

- `dotnet build src/Recollections.Blazor.Components/Recollections.Blazor.Components.csproj --nologo`
- `dotnet build src/Recollections.Blazor.UI/Recollections.Blazor.UI.csproj --nologo`
- `dotnet test src/Recollections.Api.Tests/Recollections.Api.Tests.csproj --nologo`