### PR TITLE
Prepare v0.18.1 release notes

### DIFF
--- a/src/Recollections.Blazor.UI/wwwroot/release-notes.html
+++ b/src/Recollections.Blazor.UI/wwwroot/release-notes.html
@@ -1,22 +1,12 @@
 <h3>New features</h3>
 <ul>
-    <li>First few images visible directly in timeline</li>
-    <li>"On this day" page and banner for memories from previous years</li>
-    <li>Banner with count of new entries since last visit</li>
-    <li>Improved Being detail with related stories, map pins, and timeline layout</li>
-    <li>Map can highlight visited countries</li>
-    <li>Search in Entry picker</li>
-    <li>Direct links to Story and Beings from shared entries</li>
-    <li>Clickable links in markdown text</li>
-    <li>Image and video glyphs in thumbnails and gallery</li>
-    <li>Video size warning and better fit for tall media in detail</li>
-    <li>Restored timeline position when returning from entry detail</li>
-    <li>Better loading states, faster story lists, and small UI fixes</li>
+    <li>Timeline no longer jumps back to a previously opened entry</li>
+    <li>Related stories on Being detail are now shown only once</li>
 </ul>
 
 <div class="row">
     <div class="col-12 col-md-auto">
-        <a target="_blank" rel="noopener noreferrer" href="https://github.com/neptuo/Recollections/milestone/48?closed=1" class="btn bg-light-subtle w-100">
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/neptuo/Recollections/milestone/49?closed=1" class="btn bg-light-subtle w-100">
             <span class="fab fa-github"></span>
             See details on GitHub
         </a>


### PR DESCRIPTION
This updates the in-app release notes for **v0.18.1** so the published summary matches the fixes that shipped in the milestone.

## Summary
- add the user-facing notes for the timeline navigation fix
- note that related stories on Being detail are now deduplicated
- point the GitHub button to milestone `v0.18.1`