### PR TITLE
Add GPX track import and route management for entries

### DIFF
--- a/src/Recollections.Api.Shared/Entries/EntryModel.cs
+++ b/src/Recollections.Api.Shared/Entries/EntryModel.cs
@@ -15,6 +15,7 @@ namespace Neptuo.Recollections.Entries
         public string Text { get; set; }
 
         public List<LocationModel> Locations { get; set; } = new List<LocationModel>();
+        public EntryTrackModel Track { get; set; } = new EntryTrackModel();
 
         public EntryModel()
         { }
@@ -40,7 +41,8 @@ namespace Neptuo.Recollections.Entries
                 Id = Id,
                 Title = Title,
                 When = When,
-                Text = Text
+                Text = Text,
+                Track = Track?.Clone()
             };
 
             clone.Locations.AddRange(Locations.Select(l => l.Clone()));
@@ -54,7 +56,8 @@ namespace Neptuo.Recollections.Entries
             Title == other.Title &&
             When == other.When &&
             Text == other.Text &&
-            EqualsLocations(other.Locations);
+            EqualsLocations(other.Locations) &&
+            EqualityComparer<EntryTrackModel>.Default.Equals(Track, other.Track);
 
         protected bool EqualsLocations(List<LocationModel> other)
         {
@@ -80,6 +83,7 @@ namespace Neptuo.Recollections.Entries
             hashCode = hashCode * -1521134295 + When.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Text);
             hashCode = hashCode * -1521134295 + EqualityComparer<ICollection<LocationModel>>.Default.GetHashCode(Locations);
+            hashCode = hashCode * -1521134295 + EqualityComparer<EntryTrackModel>.Default.GetHashCode(Track);
             return hashCode;
         }
     }

--- a/src/Recollections.Api.Tests/Infrastructure/DatabaseSeeder.cs
+++ b/src/Recollections.Api.Tests/Infrastructure/DatabaseSeeder.cs
@@ -158,6 +158,7 @@ public static class DatabaseSeeder
         entry.TrackData = track.Data;
         entry.TrackPointCount = track.PointCount;
         entry.TrackTotalElevation = track.TotalElevation;
+        entry.TrackTotalDistance = track.TotalDistance;
         entry.TrackLatitude = track.Location?.Latitude;
         entry.TrackLongitude = track.Location?.Longitude;
         entry.TrackAltitude = track.Location?.Altitude;

--- a/src/Recollections.Api.Tests/Infrastructure/DatabaseSeeder.cs
+++ b/src/Recollections.Api.Tests/Infrastructure/DatabaseSeeder.cs
@@ -146,6 +146,25 @@ public static class DatabaseSeeder
         await db.SaveChangesAsync();
     }
 
+    public static async Task SeedEntryTrack(EntriesDataContext db, Entry entry, params (double latitude, double longitude, double? altitude)[] points)
+    {
+        var track = new GpxImportService().Create(points.Select(p => new LocationModel()
+        {
+            Latitude = p.latitude,
+            Longitude = p.longitude,
+            Altitude = p.altitude
+        }).ToList());
+
+        entry.TrackData = track.Data;
+        entry.TrackPointCount = track.PointCount;
+        entry.TrackLatitude = track.Location?.Latitude;
+        entry.TrackLongitude = track.Location?.Longitude;
+        entry.TrackAltitude = track.Location?.Altitude;
+        entry.Locations.Clear();
+
+        await db.SaveChangesAsync();
+    }
+
     public static async Task<Image> SeedImage(
         EntriesDataContext db,
         string imageId,

--- a/src/Recollections.Api.Tests/Infrastructure/DatabaseSeeder.cs
+++ b/src/Recollections.Api.Tests/Infrastructure/DatabaseSeeder.cs
@@ -157,6 +157,7 @@ public static class DatabaseSeeder
 
         entry.TrackData = track.Data;
         entry.TrackPointCount = track.PointCount;
+        entry.TrackTotalElevation = track.TotalElevation;
         entry.TrackLatitude = track.Location?.Latitude;
         entry.TrackLongitude = track.Location?.Longitude;
         entry.TrackAltitude = track.Location?.Altitude;

--- a/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
@@ -5,6 +7,7 @@ using Neptuo.Recollections.Entries;
 using Neptuo.Recollections.Sharing;
 using Neptuo.Recollections.Tests.Infrastructure;
 using Xunit;
+using EntriesDataContext = Neptuo.Recollections.Entries.DataContext;
 
 namespace Neptuo.Recollections.Tests.Sharing;
 
@@ -90,6 +93,11 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
         Assert.Equal(10d, entry.Model.Track.TotalElevation);
         Assert.NotNull(entry.Model.Track.TotalDistance);
         Assert.True(entry.Model.Track.TotalDistance > 0);
+
+        var storedTrack = await GetStoredTrackAsync();
+        Assert.NotNull(storedTrack);
+        Assert.Contains("49.195", storedTrack);
+        Assert.DoesNotContain("50.111", storedTrack);
     }
 
     [Fact]
@@ -219,6 +227,7 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
         getResponse = await client.GetAsync($"/api/entries/{EntryId}");
         entry = await getResponse.ReadJsonAsync<AuthorizedModel<EntryModel>>();
         Assert.False(entry.Model.Track.HasValue());
+        Assert.Null(await GetStoredTrackAsync());
     }
 
     private static MultipartFormDataContent CreateTrackUpload(string gpx, string fileName = "track.gpx")
@@ -269,5 +278,20 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
         public long Length => 0;
 
         public Stream OpenReadStream() => throw exception;
+    }
+
+    private async Task<string> GetStoredTrackAsync()
+    {
+        using var scope = factory.Services.CreateScope();
+        var entriesDb = scope.ServiceProvider.GetRequiredService<EntriesDataContext>();
+        var fileStorage = scope.ServiceProvider.GetRequiredService<IFileStorage>();
+
+        var entry = await entriesDb.Entries.SingleAsync(e => e.Id == EntryId);
+        await using var stream = await fileStorage.FindAsync(entry, EntryFileType.Track);
+        if (stream == null)
+            return null;
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return await reader.ReadToEndAsync();
     }
 }

--- a/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
@@ -1,0 +1,196 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Neptuo.Recollections.Entries;
+using Neptuo.Recollections.Sharing;
+using Neptuo.Recollections.Tests.Infrastructure;
+using Xunit;
+
+namespace Neptuo.Recollections.Tests.Sharing;
+
+public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
+{
+    private readonly ApiFactory factory;
+
+    private const string OwnerUserId = "track-owner-id";
+    private const string OwnerUserName = "trackowner";
+    private const string ReaderUserId = "track-reader-id";
+    private const string ReaderUserName = "trackreader";
+    private const string CoOwnerUserId = "track-coowner-id";
+    private const string CoOwnerUserName = "trackcoowner";
+
+    private const string EntryId = "track-entry-id";
+
+    public EntryTrackImportTests(ApiFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await factory.SeedAsync(nameof(EntryTrackImportTests), async (accountsDb, entriesDb) =>
+        {
+            await DatabaseSeeder.SeedUser(accountsDb, OwnerUserId, OwnerUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, ReaderUserId, ReaderUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, CoOwnerUserId, CoOwnerUserName);
+
+            await DatabaseSeeder.SeedConnection(accountsDb, OwnerUserId, ReaderUserId, Permission.Read, Permission.Read);
+            await DatabaseSeeder.SeedConnection(accountsDb, OwnerUserId, CoOwnerUserId, Permission.CoOwner, Permission.Read);
+
+            var entry = await DatabaseSeeder.SeedEntry(entriesDb, EntryId, OwnerUserId, isSharingInherited: true);
+            await DatabaseSeeder.SeedEntryLocation(entriesDb, entry, 48.100, 17.100);
+        });
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task TrackImport_AsCoOwner_ReplacesEntryTrackData()
+    {
+        var client = factory.CreateClientForUser(CoOwnerUserId, CoOwnerUserName);
+
+        var response = await client.PostAsync($"/api/entries/{EntryId}/track", CreateTrackUpload(CreateGpx([
+            (50.087, 14.421, 210d),
+            (50.095, 14.430, 215d),
+            (50.103, 14.438, 220d),
+            (50.111, 14.446, 225d)
+        ])));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        response = await client.PostAsync($"/api/entries/{EntryId}/track", CreateTrackUpload(CreateGpx([
+            (49.195, 16.608, 230d),
+            (49.205, 16.618, 235d),
+            (49.215, 16.628, 240d)
+        ])));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var model = await response.ReadJsonAsync<EntryModel>();
+        Assert.Single(model.Locations);
+        Assert.Equal(48.100, model.Locations[0].Latitude);
+        Assert.Equal(17.100, model.Locations[0].Longitude);
+        Assert.True(model.Track.HasValue());
+        Assert.Equal(3, model.Track.PointCount);
+        Assert.Equal(49.205, model.Track.Location.Latitude);
+        Assert.Equal(16.618, model.Track.Location.Longitude);
+
+        var decoded = new GpxImportService().Decode(model.Track.Data);
+        Assert.Equal(3, decoded.Count);
+        Assert.Equal(49.195, decoded[0].Latitude);
+        Assert.Equal(16.628, decoded[2].Longitude);
+
+        var entryResponse = await client.GetAsync($"/api/entries/{EntryId}");
+        Assert.Equal(HttpStatusCode.OK, entryResponse.StatusCode);
+        var entry = await entryResponse.ReadJsonAsync<AuthorizedModel<EntryModel>>();
+        Assert.True(entry.Model.Track.HasValue());
+        Assert.Single(entry.Model.Locations);
+        Assert.Equal(3, entry.Model.Track.PointCount);
+    }
+
+    [Fact]
+    public async Task TrackImport_AsReader_ReturnsUnauthorized()
+    {
+        var client = factory.CreateClientForUser(ReaderUserId, ReaderUserName);
+        var response = await client.PostAsync($"/api/entries/{EntryId}/track", CreateTrackUpload(CreateGpx([
+            (50.087, 14.421, 210d),
+            (50.095, 14.430, 215d)
+        ])));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TrackImport_InvalidFile_ReturnsBadRequest()
+    {
+        var client = factory.CreateClientForUser(CoOwnerUserId, CoOwnerUserName);
+        var response = await client.PostAsync($"/api/entries/{EntryId}/track", CreateTrackUpload("<gpx></gpx>"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TrackImport_LargeTrack_IsSimplified()
+    {
+        var client = factory.CreateClientForUser(CoOwnerUserId, CoOwnerUserName);
+        var response = await client.PostAsync(
+            $"/api/entries/{EntryId}/track",
+            CreateTrackUpload(CreateLargeGpx(GpxImportService.MaxLocationCount + 75))
+        );
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var model = await response.ReadJsonAsync<EntryModel>();
+        Assert.True(model.Track.HasValue());
+        Assert.Equal(GpxImportService.MaxLocationCount, model.Track.PointCount);
+
+        var decoded = new GpxImportService().Decode(model.Track.Data);
+        Assert.Equal(GpxImportService.MaxLocationCount, decoded.Count);
+        Assert.Equal(50d, decoded[0].Latitude);
+        Assert.Equal(14d, decoded[0].Longitude);
+        Assert.Equal(50d + ((GpxImportService.MaxLocationCount + 75 - 1) * 0.001d), decoded[^1].Latitude);
+    }
+
+    [Fact]
+    public async Task TrackImport_CanBeClearedByEntryUpdate()
+    {
+        var client = factory.CreateClientForUser(CoOwnerUserId, CoOwnerUserName);
+        var importResponse = await client.PostAsync($"/api/entries/{EntryId}/track", CreateTrackUpload(CreateGpx([
+            (50.087, 14.421, 210d),
+            (50.095, 14.430, 215d)
+        ])));
+        Assert.Equal(HttpStatusCode.OK, importResponse.StatusCode);
+
+        var getResponse = await client.GetAsync($"/api/entries/{EntryId}");
+        var entry = await getResponse.ReadJsonAsync<AuthorizedModel<EntryModel>>();
+
+        var json = $"{{\"Id\":\"{EntryId}\",\"Title\":\"{entry.Model.Title}\",\"When\":\"{entry.Model.When:O}\",\"Text\":null,\"Locations\":[],\"Track\":{{\"Data\":null,\"PointCount\":0,\"Location\":null}}}}";
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var updateResponse = await client.PutAsync($"/api/entries/{EntryId}", content);
+
+        Assert.Equal(HttpStatusCode.NoContent, updateResponse.StatusCode);
+
+        getResponse = await client.GetAsync($"/api/entries/{EntryId}");
+        entry = await getResponse.ReadJsonAsync<AuthorizedModel<EntryModel>>();
+        Assert.False(entry.Model.Track.HasValue());
+    }
+
+    private static MultipartFormDataContent CreateTrackUpload(string gpx, string fileName = "track.gpx")
+    {
+        var content = new MultipartFormDataContent();
+        var file = new ByteArrayContent(Encoding.UTF8.GetBytes(gpx));
+        file.Headers.ContentType = new MediaTypeHeaderValue("application/gpx+xml");
+        content.Add(file, "file", fileName);
+        return content;
+    }
+
+    private static string CreateLargeGpx(int count)
+    {
+        var points = Enumerable.Range(0, count)
+            .Select(i => (50d + (i * 0.001d), 14d + (i * 0.001d), 200d + i))
+            .ToArray();
+
+        return CreateGpx(points);
+    }
+
+    private static string CreateGpx((double latitude, double longitude, double altitude)[] points)
+    {
+        var track = new StringBuilder();
+        foreach (var point in points)
+        {
+            track.AppendLine(
+                $"<trkpt lat=\"{point.latitude.ToString(System.Globalization.CultureInfo.InvariantCulture)}\" lon=\"{point.longitude.ToString(System.Globalization.CultureInfo.InvariantCulture)}\"><ele>{point.altitude.ToString(System.Globalization.CultureInfo.InvariantCulture)}</ele></trkpt>"
+            );
+        }
+
+        return $$"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <gpx version="1.1" creator="tests" xmlns="http://www.topografix.com/GPX/1/1">
+              <trk>
+                <name>Sample track</name>
+                <trkseg>
+            {{track}}
+                </trkseg>
+              </trk>
+            </gpx>
+            """;
+    }
+}

--- a/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
@@ -129,6 +129,20 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
     }
 
     [Fact]
+    public void TrackImport_DecodeTruncatedData_ReturnsEmptyList()
+    {
+        var service = new GpxImportService();
+        var track = service.Create([
+            new LocationModel() { Latitude = 50.087, Longitude = 14.421 },
+            new LocationModel() { Latitude = 50.095, Longitude = 14.430 }
+        ]);
+
+        var decoded = service.Decode(track.Data[..^1]);
+
+        Assert.Empty(decoded);
+    }
+
+    [Fact]
     public void TrackImport_ComputesTotalElevationGain()
     {
         var service = new GpxImportService();

--- a/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
@@ -70,6 +70,7 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
         Assert.Equal(17.100, model.Locations[0].Longitude);
         Assert.True(model.Track.HasValue());
         Assert.Equal(3, model.Track.PointCount);
+        Assert.Equal(10d, model.Track.TotalElevation);
         Assert.Equal(49.205, model.Track.Location.Latitude);
         Assert.Equal(16.618, model.Track.Location.Longitude);
 
@@ -84,6 +85,7 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
         Assert.True(entry.Model.Track.HasValue());
         Assert.Single(entry.Model.Locations);
         Assert.Equal(3, entry.Model.Track.PointCount);
+        Assert.Equal(10d, entry.Model.Track.TotalElevation);
     }
 
     [Fact]
@@ -127,6 +129,21 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
     }
 
     [Fact]
+    public void TrackImport_ComputesTotalElevationGain()
+    {
+        var service = new GpxImportService();
+
+        var track = service.Create([
+            new LocationModel() { Latitude = 50.087, Longitude = 14.421, Altitude = 100d },
+            new LocationModel() { Latitude = 50.095, Longitude = 14.430, Altitude = 120d },
+            new LocationModel() { Latitude = 50.103, Longitude = 14.438, Altitude = 110d },
+            new LocationModel() { Latitude = 50.111, Longitude = 14.446, Altitude = 150d }
+        ]);
+
+        Assert.Equal(60d, track.TotalElevation);
+    }
+
+    [Fact]
     public async Task TrackImport_LargeTrack_IsSimplified()
     {
         var client = factory.CreateClientForUser(CoOwnerUserId, CoOwnerUserName);
@@ -161,7 +178,7 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
         var getResponse = await client.GetAsync($"/api/entries/{EntryId}");
         var entry = await getResponse.ReadJsonAsync<AuthorizedModel<EntryModel>>();
 
-        var json = $"{{\"Id\":\"{EntryId}\",\"Title\":\"{entry.Model.Title}\",\"When\":\"{entry.Model.When:O}\",\"Text\":null,\"Locations\":[],\"Track\":{{\"Data\":null,\"PointCount\":0,\"Location\":null}}}}";
+        var json = $"{{\"Id\":\"{EntryId}\",\"Title\":\"{entry.Model.Title}\",\"When\":\"{entry.Model.When:O}\",\"Text\":null,\"Locations\":[],\"Track\":{{\"Data\":null,\"PointCount\":0,\"TotalElevation\":null,\"Location\":null}}}}";
         var content = new StringContent(json, Encoding.UTF8, "application/json");
         var updateResponse = await client.PutAsync($"/api/entries/{EntryId}", content);
 

--- a/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
@@ -71,6 +71,8 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
         Assert.True(model.Track.HasValue());
         Assert.Equal(3, model.Track.PointCount);
         Assert.Equal(10d, model.Track.TotalElevation);
+        Assert.NotNull(model.Track.TotalDistance);
+        Assert.True(model.Track.TotalDistance > 0);
         Assert.Equal(49.205, model.Track.Location.Latitude);
         Assert.Equal(16.618, model.Track.Location.Longitude);
 
@@ -86,6 +88,8 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
         Assert.Single(entry.Model.Locations);
         Assert.Equal(3, entry.Model.Track.PointCount);
         Assert.Equal(10d, entry.Model.Track.TotalElevation);
+        Assert.NotNull(entry.Model.Track.TotalDistance);
+        Assert.True(entry.Model.Track.TotalDistance > 0);
     }
 
     [Fact]
@@ -158,6 +162,20 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
     }
 
     [Fact]
+    public void TrackImport_ComputesTotalDistance()
+    {
+        var service = new GpxImportService();
+
+        var track = service.Create([
+            new LocationModel() { Latitude = 0d, Longitude = 0d },
+            new LocationModel() { Latitude = 0d, Longitude = 0.001d },
+            new LocationModel() { Latitude = 0d, Longitude = 0.002d }
+        ]);
+
+        Assert.InRange(track.TotalDistance ?? 0d, 222.3d, 222.5d);
+    }
+
+    [Fact]
     public async Task TrackImport_LargeTrack_IsSimplified()
     {
         var client = factory.CreateClientForUser(CoOwnerUserId, CoOwnerUserName);
@@ -192,7 +210,7 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
         var getResponse = await client.GetAsync($"/api/entries/{EntryId}");
         var entry = await getResponse.ReadJsonAsync<AuthorizedModel<EntryModel>>();
 
-        var json = $"{{\"Id\":\"{EntryId}\",\"Title\":\"{entry.Model.Title}\",\"When\":\"{entry.Model.When:O}\",\"Text\":null,\"Locations\":[],\"Track\":{{\"Data\":null,\"PointCount\":0,\"TotalElevation\":null,\"Location\":null}}}}";
+        var json = $"{{\"Id\":\"{EntryId}\",\"Title\":\"{entry.Model.Title}\",\"When\":\"{entry.Model.When:O}\",\"Text\":null,\"Locations\":[],\"Track\":{{\"Data\":null,\"PointCount\":0,\"TotalElevation\":null,\"TotalDistance\":null,\"Location\":null}}}}";
         var content = new StringContent(json, Encoding.UTF8, "application/json");
         var updateResponse = await client.PutAsync($"/api/entries/{EntryId}", content);
 

--- a/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
@@ -108,6 +108,25 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
     }
 
     [Fact]
+    public void TrackImport_InvalidStream_ThrowsValidationException()
+    {
+        var service = new GpxImportService();
+
+        Assert.Throws<TrackImportValidationException>(() => service.Parse(new ThrowingFileInput(new IOException("Broken upload stream."))));
+    }
+
+    [Fact]
+    public void TrackImport_MissingCoordinates_ThrowsValidationException()
+    {
+        var service = new GpxImportService();
+
+        Assert.Throws<TrackImportValidationException>(() => service.Create([
+            new LocationModel() { Latitude = 50.087, Longitude = 14.421 },
+            new LocationModel() { Latitude = 50.095 }
+        ]));
+    }
+
+    [Fact]
     public async Task TrackImport_LargeTrack_IsSimplified()
     {
         var client = factory.CreateClientForUser(CoOwnerUserId, CoOwnerUserName);
@@ -192,5 +211,14 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
               </trk>
             </gpx>
             """;
+    }
+
+    private sealed class ThrowingFileInput(Exception exception) : IFileInput
+    {
+        public string ContentType => "application/gpx+xml";
+        public string FileName => "track.gpx";
+        public long Length => 0;
+
+        public Stream OpenReadStream() => throw exception;
     }
 }

--- a/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/EntryTrackImportTests.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text;
 using Neptuo.Recollections.Entries;
 using Neptuo.Recollections.Sharing;
@@ -228,6 +229,47 @@ public class EntryTrackImportTests : IClassFixture<ApiFactory>, IAsyncLifetime
         entry = await getResponse.ReadJsonAsync<AuthorizedModel<EntryModel>>();
         Assert.False(entry.Model.Track.HasValue());
         Assert.Null(await GetStoredTrackAsync());
+    }
+
+    [Fact]
+    public async Task TrackImport_EntryUpdate_IgnoresClientProvidedTrackPayload()
+    {
+        var client = factory.CreateClientForUser(CoOwnerUserId, CoOwnerUserName);
+        var importResponse = await client.PostAsync($"/api/entries/{EntryId}/track", CreateTrackUpload(CreateGpx([
+            (50.087, 14.421, 210d),
+            (50.095, 14.430, 215d),
+            (50.103, 14.438, 220d)
+        ])));
+        Assert.Equal(HttpStatusCode.OK, importResponse.StatusCode);
+
+        var imported = await importResponse.ReadJsonAsync<EntryModel>();
+
+        var getResponse = await client.GetAsync($"/api/entries/{EntryId}");
+        var entry = await getResponse.ReadJsonAsync<AuthorizedModel<EntryModel>>();
+        entry.Model.Title = "Updated title";
+        entry.Model.Track = new EntryTrackModel()
+        {
+            Data = "tampered-track-data",
+            PointCount = 999,
+            TotalElevation = 999d,
+            TotalDistance = 999d,
+            Location = new LocationModel() { Latitude = 0d, Longitude = 0d, Altitude = 0d }
+        };
+
+        var updateResponse = await client.PutAsJsonAsync($"/api/entries/{EntryId}", entry.Model);
+
+        Assert.Equal(HttpStatusCode.NoContent, updateResponse.StatusCode);
+
+        getResponse = await client.GetAsync($"/api/entries/{EntryId}");
+        entry = await getResponse.ReadJsonAsync<AuthorizedModel<EntryModel>>();
+        Assert.Equal("Updated title", entry.Model.Title);
+        Assert.Equal(imported.Track.Data, entry.Model.Track.Data);
+        Assert.Equal(imported.Track.PointCount, entry.Model.Track.PointCount);
+        Assert.Equal(imported.Track.TotalElevation, entry.Model.Track.TotalElevation);
+        Assert.Equal(imported.Track.TotalDistance, entry.Model.Track.TotalDistance);
+        Assert.Equal(imported.Track.Location.Latitude, entry.Model.Track.Location.Latitude);
+        Assert.Equal(imported.Track.Location.Longitude, entry.Model.Track.Location.Longitude);
+        Assert.Equal(imported.Track.Location.Altitude, entry.Model.Track.Location.Altitude);
     }
 
     private static MultipartFormDataContent CreateTrackUpload(string gpx, string fileName = "track.gpx")

--- a/src/Recollections.Api.Tests/Sharing/MapEndpointTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/MapEndpointTests.cs
@@ -22,6 +22,7 @@ public class MapListEndpointTests : IClassFixture<ApiFactory>, IAsyncLifetime
     private const string OwnEntryId = "mp-list-entry-own";
     private const string NoLocationEntryId = "mp-list-entry-no-location";
     private const string TrackFallbackEntryId = "mp-list-entry-track-fallback";
+    private const string TrackPreferredEntryId = "mp-list-entry-track-preferred";
 
     public MapListEndpointTests(ApiFactory factory)
     {
@@ -54,6 +55,13 @@ public class MapListEndpointTests : IClassFixture<ApiFactory>, IAsyncLifetime
                 (50.020, 14.020, null),
                 (50.030, 14.030, null));
 
+            var trackPreferredEntry = await DatabaseSeeder.SeedEntry(entriesDb, TrackPreferredEntryId, UserAId, isSharingInherited: true);
+            await DatabaseSeeder.SeedImage(entriesDb, "mp-list-image-track-preferred", trackPreferredEntry, latitude: 48.100, longitude: 17.100);
+            await DatabaseSeeder.SeedEntryTrack(entriesDb, trackPreferredEntry,
+                (49.010, 15.010, null),
+                (49.020, 15.020, null),
+                (49.030, 15.030, null));
+
             await DatabaseSeeder.SeedEntry(entriesDb, NoLocationEntryId, UserAId, isSharingInherited: true);
         });
     }
@@ -75,14 +83,19 @@ public class MapListEndpointTests : IClassFixture<ApiFactory>, IAsyncLifetime
         Assert.Contains(ImageFallbackEntryId, entryIds);
         Assert.Contains(OwnEntryId, entryIds);
         Assert.Contains(TrackFallbackEntryId, entryIds);
+        Assert.Contains(TrackPreferredEntryId, entryIds);
         Assert.DoesNotContain(HiddenEntryId, entryIds);
         Assert.DoesNotContain(NoLocationEntryId, entryIds);
-        Assert.Equal(4, models.Count);
+        Assert.Equal(5, models.Count);
         Assert.All(models, model => Assert.True(model.Location?.HasValue() == true));
 
         var trackFallback = models.Single(model => model.Id == TrackFallbackEntryId);
         Assert.Equal(50.02, trackFallback.Location.Latitude);
         Assert.Equal(14.02, trackFallback.Location.Longitude);
+
+        var trackPreferred = models.Single(model => model.Id == TrackPreferredEntryId);
+        Assert.Equal(49.02, trackPreferred.Location.Latitude);
+        Assert.Equal(15.02, trackPreferred.Location.Longitude);
     }
 
     [Fact]

--- a/src/Recollections.Api.Tests/Sharing/MapEndpointTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/MapEndpointTests.cs
@@ -21,6 +21,7 @@ public class MapListEndpointTests : IClassFixture<ApiFactory>, IAsyncLifetime
     private const string HiddenEntryId = "mp-list-entry-hidden";
     private const string OwnEntryId = "mp-list-entry-own";
     private const string NoLocationEntryId = "mp-list-entry-no-location";
+    private const string TrackFallbackEntryId = "mp-list-entry-track-fallback";
 
     public MapListEndpointTests(ApiFactory factory)
     {
@@ -47,6 +48,12 @@ public class MapListEndpointTests : IClassFixture<ApiFactory>, IAsyncLifetime
             var ownEntry = await DatabaseSeeder.SeedEntry(entriesDb, OwnEntryId, UserBId, isSharingInherited: true);
             await DatabaseSeeder.SeedEntryLocation(entriesDb, ownEntry, 51.507, -0.128);
 
+            var trackFallbackEntry = await DatabaseSeeder.SeedEntry(entriesDb, TrackFallbackEntryId, UserAId, isSharingInherited: true);
+            await DatabaseSeeder.SeedEntryTrack(entriesDb, trackFallbackEntry,
+                (50.010, 14.010, null),
+                (50.020, 14.020, null),
+                (50.030, 14.030, null));
+
             await DatabaseSeeder.SeedEntry(entriesDb, NoLocationEntryId, UserAId, isSharingInherited: true);
         });
     }
@@ -67,10 +74,15 @@ public class MapListEndpointTests : IClassFixture<ApiFactory>, IAsyncLifetime
         Assert.Contains(VisibleEntryId, entryIds);
         Assert.Contains(ImageFallbackEntryId, entryIds);
         Assert.Contains(OwnEntryId, entryIds);
+        Assert.Contains(TrackFallbackEntryId, entryIds);
         Assert.DoesNotContain(HiddenEntryId, entryIds);
         Assert.DoesNotContain(NoLocationEntryId, entryIds);
-        Assert.Equal(3, models.Count);
+        Assert.Equal(4, models.Count);
         Assert.All(models, model => Assert.True(model.Location?.HasValue() == true));
+
+        var trackFallback = models.Single(model => model.Id == TrackFallbackEntryId);
+        Assert.Equal(50.02, trackFallback.Location.Latitude);
+        Assert.Equal(14.02, trackFallback.Location.Longitude);
     }
 
     [Fact]

--- a/src/Recollections.Api/Entries/Controllers/EntryController.cs
+++ b/src/Recollections.Api/Entries/Controllers/EntryController.cs
@@ -29,9 +29,10 @@ namespace Neptuo.Recollections.Entries.Controllers
         private readonly ShareDeleter shareDeleter;
         private readonly IUserNameProvider userNames;
         private readonly FreeLimitsChecker freeLimits;
+        private readonly IFileStorage fileStorage;
         private readonly GpxImportService gpxImportService;
-
-        public EntryController(DataContext db, ImageService imageService, ShareStatusService shareStatus, ShareDeleter shareDeleter, IUserNameProvider userNames, FreeLimitsChecker freeLimits, GpxImportService gpxImportService)
+ 
+        public EntryController(DataContext db, ImageService imageService, ShareStatusService shareStatus, ShareDeleter shareDeleter, IUserNameProvider userNames, FreeLimitsChecker freeLimits, IFileStorage fileStorage, GpxImportService gpxImportService)
             : base(db, shareStatus)
         {
             Ensure.NotNull(db, "db");
@@ -40,6 +41,7 @@ namespace Neptuo.Recollections.Entries.Controllers
             Ensure.NotNull(shareDeleter, "shareDeleter");
             Ensure.NotNull(userNames, "userNames");
             Ensure.NotNull(freeLimits, "freeLimits");
+            Ensure.NotNull(fileStorage, "fileStorage");
             Ensure.NotNull(gpxImportService, "gpxImportService");
             this.db = db;
             this.imageService = imageService;
@@ -47,6 +49,7 @@ namespace Neptuo.Recollections.Entries.Controllers
             this.shareDeleter = shareDeleter;
             this.userNames = userNames;
             this.freeLimits = freeLimits;
+            this.fileStorage = fileStorage;
             this.gpxImportService = gpxImportService;
         }
 
@@ -127,12 +130,16 @@ namespace Neptuo.Recollections.Entries.Controllers
                     }
                 }
             }
-
+ 
+            bool shouldDeleteTrackFile = !String.IsNullOrEmpty(entity.TrackData) && (model.Track == null || !model.Track.HasValue());
             MapModelToEntity(model, entity);
-
+ 
             db.Entries.Update(entity);
             await db.SaveChangesAsync();
 
+            if (shouldDeleteTrackFile)
+                await fileStorage.DeleteAsync(entity, EntryFileType.Track);
+ 
             return NoContent();
         });
 
@@ -165,6 +172,9 @@ namespace Neptuo.Recollections.Entries.Controllers
             if (!await freeLimits.CanSetGpsAsync(userId, track.HasValue() ? 1 : 0))
                 return PremiumRequired();
 
+            using (Stream source = file.OpenReadStream())
+                await fileStorage.SaveAsync(entity, source, EntryFileType.Track);
+ 
             entity.TrackData = track.Data;
             entity.TrackPointCount = track.PointCount;
             entity.TrackTotalElevation = track.TotalElevation;
@@ -186,10 +196,12 @@ namespace Neptuo.Recollections.Entries.Controllers
         {
             await imageService.DeleteAllAsync(entity);
             await shareDeleter.DeleteEntrySharesAsync(id);
-
+ 
             db.Entries.Remove(entity);
             await db.SaveChangesAsync();
 
+            await fileStorage.DeleteAsync(entity, EntryFileType.Track);
+ 
             return Ok();
         });
 

--- a/src/Recollections.Api/Entries/Controllers/EntryController.cs
+++ b/src/Recollections.Api/Entries/Controllers/EntryController.cs
@@ -167,6 +167,7 @@ namespace Neptuo.Recollections.Entries.Controllers
 
             entity.TrackData = track.Data;
             entity.TrackPointCount = track.PointCount;
+            entity.TrackTotalElevation = track.TotalElevation;
             entity.TrackLatitude = track.Location?.Latitude;
             entity.TrackLongitude = track.Location?.Longitude;
             entity.TrackAltitude = track.Location?.Altitude;
@@ -208,6 +209,7 @@ namespace Neptuo.Recollections.Entries.Controllers
             {
                 Data = entity.TrackData,
                 PointCount = entity.TrackPointCount ?? 0,
+                TotalElevation = entity.TrackTotalElevation,
                 Location = entity.TrackLatitude != null && entity.TrackLongitude != null
                     ? new LocationModel()
                     {
@@ -229,6 +231,7 @@ namespace Neptuo.Recollections.Entries.Controllers
             {
                 entity.TrackData = model.Track.Data;
                 entity.TrackPointCount = model.Track.PointCount;
+                entity.TrackTotalElevation = model.Track.TotalElevation;
                 entity.TrackLatitude = model.Track.Location?.Latitude;
                 entity.TrackLongitude = model.Track.Location?.Longitude;
                 entity.TrackAltitude = model.Track.Location?.Altitude;
@@ -237,6 +240,7 @@ namespace Neptuo.Recollections.Entries.Controllers
             {
                 entity.TrackData = null;
                 entity.TrackPointCount = null;
+                entity.TrackTotalElevation = null;
                 entity.TrackLatitude = null;
                 entity.TrackLongitude = null;
                 entity.TrackAltitude = null;

--- a/src/Recollections.Api/Entries/Controllers/EntryController.cs
+++ b/src/Recollections.Api/Entries/Controllers/EntryController.cs
@@ -175,13 +175,7 @@ namespace Neptuo.Recollections.Entries.Controllers
             using (Stream source = file.OpenReadStream())
                 await fileStorage.SaveAsync(entity, source, EntryFileType.Track);
  
-            entity.TrackData = track.Data;
-            entity.TrackPointCount = track.PointCount;
-            entity.TrackTotalElevation = track.TotalElevation;
-            entity.TrackTotalDistance = track.TotalDistance;
-            entity.TrackLatitude = track.Location?.Latitude;
-            entity.TrackLongitude = track.Location?.Longitude;
-            entity.TrackAltitude = track.Location?.Altitude;
+            MapTrackToEntity(track, entity);
 
             db.Entries.Update(entity);
             await db.SaveChangesAsync();
@@ -241,26 +235,8 @@ namespace Neptuo.Recollections.Entries.Controllers
             entity.Title = model.Title;
             entity.When = model.When;
             entity.Text = model.Text;
-            if (model.Track != null && model.Track.HasValue())
-            {
-                entity.TrackData = model.Track.Data;
-                entity.TrackPointCount = model.Track.PointCount;
-                entity.TrackTotalElevation = model.Track.TotalElevation;
-                entity.TrackTotalDistance = model.Track.TotalDistance;
-                entity.TrackLatitude = model.Track.Location?.Latitude;
-                entity.TrackLongitude = model.Track.Location?.Longitude;
-                entity.TrackAltitude = model.Track.Location?.Altitude;
-            }
-            else
-            {
-                entity.TrackData = null;
-                entity.TrackPointCount = null;
-                entity.TrackTotalElevation = null;
-                entity.TrackTotalDistance = null;
-                entity.TrackLatitude = null;
-                entity.TrackLongitude = null;
-                entity.TrackAltitude = null;
-            }
+            if (model.Track == null || !model.Track.HasValue())
+                ClearTrack(entity);
 
             for (int i = 0; i < model.Locations.Count; i++)
             {
@@ -284,6 +260,35 @@ namespace Neptuo.Recollections.Entries.Controllers
                 entity.Locations.RemoveAt(entity.Locations.Count - 1);
         }
 
+        private static void MapTrackToEntity(EntryTrackModel track, Entry entity)
+        {
+            if (track != null && track.HasValue())
+            {
+                entity.TrackData = track.Data;
+                entity.TrackPointCount = track.PointCount;
+                entity.TrackTotalElevation = track.TotalElevation;
+                entity.TrackTotalDistance = track.TotalDistance;
+                entity.TrackLatitude = track.Location?.Latitude;
+                entity.TrackLongitude = track.Location?.Longitude;
+                entity.TrackAltitude = track.Location?.Altitude;
+            }
+            else
+            {
+                ClearTrack(entity);
+            }
+        }
+
+        private static void ClearTrack(Entry entity)
+        {
+            entity.TrackData = null;
+            entity.TrackPointCount = null;
+            entity.TrackTotalElevation = null;
+            entity.TrackTotalDistance = null;
+            entity.TrackLatitude = null;
+            entity.TrackLongitude = null;
+            entity.TrackAltitude = null;
+        }
+ 
         public class GeoElevationResponse
         {
             public GeoElevation[] Items { get; set; }

--- a/src/Recollections.Api/Entries/Controllers/EntryController.cs
+++ b/src/Recollections.Api/Entries/Controllers/EntryController.cs
@@ -29,8 +29,9 @@ namespace Neptuo.Recollections.Entries.Controllers
         private readonly ShareDeleter shareDeleter;
         private readonly IUserNameProvider userNames;
         private readonly FreeLimitsChecker freeLimits;
+        private readonly GpxImportService gpxImportService;
 
-        public EntryController(DataContext db, ImageService imageService, ShareStatusService shareStatus, ShareDeleter shareDeleter, IUserNameProvider userNames, FreeLimitsChecker freeLimits)
+        public EntryController(DataContext db, ImageService imageService, ShareStatusService shareStatus, ShareDeleter shareDeleter, IUserNameProvider userNames, FreeLimitsChecker freeLimits, GpxImportService gpxImportService)
             : base(db, shareStatus)
         {
             Ensure.NotNull(db, "db");
@@ -39,12 +40,14 @@ namespace Neptuo.Recollections.Entries.Controllers
             Ensure.NotNull(shareDeleter, "shareDeleter");
             Ensure.NotNull(userNames, "userNames");
             Ensure.NotNull(freeLimits, "freeLimits");
+            Ensure.NotNull(gpxImportService, "gpxImportService");
             this.db = db;
             this.imageService = imageService;
             this.shareStatus = shareStatus;
             this.shareDeleter = shareDeleter;
             this.userNames = userNames;
             this.freeLimits = freeLimits;
+            this.gpxImportService = gpxImportService;
         }
 
         [HttpGet("{id}")]
@@ -133,6 +136,49 @@ namespace Neptuo.Recollections.Entries.Controllers
             return NoContent();
         });
 
+        [HttpPost("{id}/track")]
+        [Consumes("multipart/form-data")]
+        [ProducesDefaultResponseType(typeof(EntryModel))]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status402PaymentRequired)]
+        public Task<IActionResult> ImportTrack(string id, [FromForm] IFormFile file) => RunEntryAsync(id, Permission.CoOwner, async entity =>
+        {
+            if (file == null)
+                return BadRequest();
+
+            string userId = User.FindUserId();
+            if (userId == null)
+                return Unauthorized();
+
+            EntryTrackModel track;
+            try
+            {
+                track = gpxImportService.Parse(new FormFileInput(file));
+            }
+            catch (TrackImportValidationException)
+            {
+                return BadRequest();
+            }
+
+            if (!await freeLimits.CanSetGpsAsync(userId, track.HasValue() ? 1 : 0))
+                return PremiumRequired();
+
+            entity.TrackData = track.Data;
+            entity.TrackPointCount = track.PointCount;
+            entity.TrackLatitude = track.Location?.Latitude;
+            entity.TrackLongitude = track.Location?.Longitude;
+            entity.TrackAltitude = track.Location?.Altitude;
+
+            db.Entries.Update(entity);
+            await db.SaveChangesAsync();
+
+            EntryModel model = new EntryModel();
+            MapEntityToModel(entity, model);
+            return Ok(model);
+        });
+
         [HttpDelete("{id}")]
         public Task<IActionResult> Delete(string id) => RunEntryAsync(id, Permission.CoOwner, async entity => 
         {
@@ -151,12 +197,26 @@ namespace Neptuo.Recollections.Entries.Controllers
             model.Title = entity.Title;
             model.When = entity.When;
             model.Text = entity.Text;
+            model.Locations.Clear();
             model.Locations.AddRange(entity.Locations.OrderBy(l => l.Order).Select(l => new LocationModel()
             {
                 Longitude = l.Longitude,
                 Latitude = l.Latitude,
                 Altitude = l.Altitude
             }));
+            model.Track = new EntryTrackModel()
+            {
+                Data = entity.TrackData,
+                PointCount = entity.TrackPointCount ?? 0,
+                Location = entity.TrackLatitude != null && entity.TrackLongitude != null
+                    ? new LocationModel()
+                    {
+                        Latitude = entity.TrackLatitude,
+                        Longitude = entity.TrackLongitude,
+                        Altitude = entity.TrackAltitude
+                    }
+                    : null
+            };
         }
 
         private void MapModelToEntity(EntryModel model, Entry entity)
@@ -165,6 +225,22 @@ namespace Neptuo.Recollections.Entries.Controllers
             entity.Title = model.Title;
             entity.When = model.When;
             entity.Text = model.Text;
+            if (model.Track != null && model.Track.HasValue())
+            {
+                entity.TrackData = model.Track.Data;
+                entity.TrackPointCount = model.Track.PointCount;
+                entity.TrackLatitude = model.Track.Location?.Latitude;
+                entity.TrackLongitude = model.Track.Location?.Longitude;
+                entity.TrackAltitude = model.Track.Location?.Altitude;
+            }
+            else
+            {
+                entity.TrackData = null;
+                entity.TrackPointCount = null;
+                entity.TrackLatitude = null;
+                entity.TrackLongitude = null;
+                entity.TrackAltitude = null;
+            }
 
             for (int i = 0; i < model.Locations.Count; i++)
             {
@@ -184,7 +260,7 @@ namespace Neptuo.Recollections.Entries.Controllers
                 locationEntity.Altitude = location.Altitude;
             }
 
-            if (entity.Locations.Count > model.Locations.Count)
+            while (entity.Locations.Count > model.Locations.Count)
                 entity.Locations.RemoveAt(entity.Locations.Count - 1);
         }
 

--- a/src/Recollections.Api/Entries/Controllers/EntryController.cs
+++ b/src/Recollections.Api/Entries/Controllers/EntryController.cs
@@ -168,6 +168,7 @@ namespace Neptuo.Recollections.Entries.Controllers
             entity.TrackData = track.Data;
             entity.TrackPointCount = track.PointCount;
             entity.TrackTotalElevation = track.TotalElevation;
+            entity.TrackTotalDistance = track.TotalDistance;
             entity.TrackLatitude = track.Location?.Latitude;
             entity.TrackLongitude = track.Location?.Longitude;
             entity.TrackAltitude = track.Location?.Altitude;
@@ -210,6 +211,7 @@ namespace Neptuo.Recollections.Entries.Controllers
                 Data = entity.TrackData,
                 PointCount = entity.TrackPointCount ?? 0,
                 TotalElevation = entity.TrackTotalElevation,
+                TotalDistance = entity.TrackTotalDistance,
                 Location = entity.TrackLatitude != null && entity.TrackLongitude != null
                     ? new LocationModel()
                     {
@@ -232,6 +234,7 @@ namespace Neptuo.Recollections.Entries.Controllers
                 entity.TrackData = model.Track.Data;
                 entity.TrackPointCount = model.Track.PointCount;
                 entity.TrackTotalElevation = model.Track.TotalElevation;
+                entity.TrackTotalDistance = model.Track.TotalDistance;
                 entity.TrackLatitude = model.Track.Location?.Latitude;
                 entity.TrackLongitude = model.Track.Location?.Longitude;
                 entity.TrackAltitude = model.Track.Location?.Altitude;
@@ -241,6 +244,7 @@ namespace Neptuo.Recollections.Entries.Controllers
                 entity.TrackData = null;
                 entity.TrackPointCount = null;
                 entity.TrackTotalElevation = null;
+                entity.TrackTotalDistance = null;
                 entity.TrackLatitude = null;
                 entity.TrackLongitude = null;
                 entity.TrackAltitude = null;

--- a/src/Recollections.Api/Entries/EntriesStartup.cs
+++ b/src/Recollections.Api/Entries/EntriesStartup.cs
@@ -83,6 +83,7 @@ namespace Neptuo.Recollections.Entries
             services
                 .AddTransient<ImageService>()
                 .AddTransient<VideoService>()
+                .AddTransient<GpxImportService>()
                 .AddTransient<ImageResizeService>()
                 .AddTransient<EntryMediaMapper>()
                 .AddTransient<EntryListMapper>()

--- a/src/Recollections.Api/Entries/Services/MapService.cs
+++ b/src/Recollections.Api/Entries/Services/MapService.cs
@@ -61,6 +61,8 @@ public class MapService
             var item = results[i];
             if (HasNotLocationValue(item))
             {
+                // When an entry has an imported track, its representative location is the
+                // authoritative entry-level pin and intentionally wins over media fallbacks.
                 var source = items[i];
                 item.Location = source.TrackLocation;
             }

--- a/src/Recollections.Api/Entries/Services/MapService.cs
+++ b/src/Recollections.Api/Entries/Services/MapService.cs
@@ -28,15 +28,23 @@ public class MapService
             {
                 Id = e.Id,
                 Title = e.Title,
-                Location = e.Locations.Select(l => new LocationModel()
-                {
-                    Latitude = l.Latitude,
-                    Longitude = l.Longitude,
-                    Altitude = l.Altitude
-                }).FirstOrDefault(),
-                TrackLatitude = e.TrackLatitude,
-                TrackLongitude = e.TrackLongitude,
-                TrackAltitude = e.TrackAltitude
+                Location = e.Locations
+                    .Where(l => l.Latitude != null && l.Longitude != null)
+                    .Select(l => new LocationModel()
+                    {
+                        Latitude = l.Latitude,
+                        Longitude = l.Longitude,
+                        Altitude = l.Altitude
+                    })
+                    .FirstOrDefault(),
+                TrackLocation = e.TrackLatitude != null && e.TrackLongitude != null
+                    ? new LocationModel()
+                    {
+                        Latitude = e.TrackLatitude,
+                        Longitude = e.TrackLongitude,
+                        Altitude = e.TrackAltitude
+                    }
+                    : null
             })
             .ToListAsync();
 
@@ -51,6 +59,12 @@ public class MapService
         for (int i = 0; i < results.Count; i++)
         {
             var item = results[i];
+            if (HasNotLocationValue(item))
+            {
+                var source = items[i];
+                item.Location = source.TrackLocation;
+            }
+
             if (HasNotLocationValue(item))
             {
                 var location = await dataContext.Images
@@ -79,20 +93,6 @@ public class MapService
                     .FirstOrDefaultAsync();
 
                 item.Location = location;
-            }
-
-            if (HasNotLocationValue(item))
-            {
-                var source = items[i];
-                if (source.TrackLatitude != null && source.TrackLongitude != null)
-                {
-                    item.Location = new LocationModel()
-                    {
-                        Latitude = source.TrackLatitude,
-                        Longitude = source.TrackLongitude,
-                        Altitude = source.TrackAltitude
-                    };
-                }
             }
 
             if (HasNotLocationValue(item))

--- a/src/Recollections.Api/Entries/Services/MapService.cs
+++ b/src/Recollections.Api/Entries/Services/MapService.cs
@@ -22,9 +22,9 @@ public class MapService
 
     public async Task<List<MapEntryModel>> GetAsync(IQueryable<Entry> query, string[] userIds, ConnectedUsersModel connectedUsers)
     {
-        List<MapEntryModel> results = await shareStatus
+        var items = await shareStatus
             .OwnedByOrExplicitlySharedWithUser(dataContext, query, userIds, connectedUsers)
-            .Select(e => new MapEntryModel()
+            .Select(e => new
             {
                 Id = e.Id,
                 Title = e.Title,
@@ -33,13 +33,24 @@ public class MapService
                     Latitude = l.Latitude,
                     Longitude = l.Longitude,
                     Altitude = l.Altitude
-                }).FirstOrDefault()
+                }).FirstOrDefault(),
+                TrackLatitude = e.TrackLatitude,
+                TrackLongitude = e.TrackLongitude,
+                TrackAltitude = e.TrackAltitude
             })
             .ToListAsync();
 
-        List<MapEntryModel> toRemove = new List<MapEntryModel>();
-        foreach (var item in results)
+        List<MapEntryModel> results = items.Select(i => new MapEntryModel()
         {
+            Id = i.Id,
+            Title = i.Title,
+            Location = i.Location
+        }).ToList();
+
+        List<MapEntryModel> toRemove = new List<MapEntryModel>();
+        for (int i = 0; i < results.Count; i++)
+        {
+            var item = results[i];
             if (HasNotLocationValue(item))
             {
                 var location = await dataContext.Images
@@ -68,6 +79,20 @@ public class MapService
                     .FirstOrDefaultAsync();
 
                 item.Location = location;
+            }
+
+            if (HasNotLocationValue(item))
+            {
+                var source = items[i];
+                if (source.TrackLatitude != null && source.TrackLongitude != null)
+                {
+                    item.Location = new LocationModel()
+                    {
+                        Latitude = source.TrackLatitude,
+                        Longitude = source.TrackLongitude,
+                        Altitude = source.TrackAltitude
+                    };
+                }
             }
 
             if (HasNotLocationValue(item))

--- a/src/Recollections.Blazor.Components/Components/FileUpload.razor
+++ b/src/Recollections.Blazor.Components/Components/FileUpload.razor
@@ -1,5 +1,5 @@
 ﻿<form @ref="FormElement" class="inline-form" action="@Url">
-    <input type="file" multiple class="d-none" />
+    <input type="file" multiple="@IsMultiple" accept="@Accept" class="d-none" />
     <button type="button" class="btn btn-sm btn-primary">
         <Icon Identifier="image" />
         @Text

--- a/src/Recollections.Blazor.Components/Components/FileUpload.razor
+++ b/src/Recollections.Blazor.Components/Components/FileUpload.razor
@@ -1,4 +1,4 @@
-﻿<form @ref="FormElement" class="inline-form" action="@Url">
+<form @ref="FormElement" class="inline-form @CssClass" action="@Url">
     <input type="file" multiple="@IsMultiple" accept="@Accept" class="d-none" />
     <button type="button" class="btn btn-sm btn-primary">
         <Icon Identifier="image" />

--- a/src/Recollections.Blazor.Components/Components/FileUpload.razor.cs
+++ b/src/Recollections.Blazor.Components/Components/FileUpload.razor.cs
@@ -40,6 +40,12 @@ namespace Neptuo.Recollections.Components
         [Parameter]
         public ElementReference DragAndDropContainer { get; set; }
 
+        [Parameter]
+        public string Accept { get; set; }
+
+        [Parameter]
+        public bool IsMultiple { get; set; } = true;
+
         internal ElementReference FormElement { get; private set; }
 
         protected Modal UploadError { get; set; }

--- a/src/Recollections.Blazor.Components/Components/FileUpload.razor.cs
+++ b/src/Recollections.Blazor.Components/Components/FileUpload.razor.cs
@@ -46,6 +46,9 @@ namespace Neptuo.Recollections.Components
         [Parameter]
         public bool IsMultiple { get; set; } = true;
 
+        [Parameter]
+        public string CssClass { get; set; }
+
         internal ElementReference FormElement { get; private set; }
 
         protected Modal UploadError { get; set; }
@@ -73,5 +76,8 @@ namespace Neptuo.Recollections.Components
             if (formBinding != null)
                 await formBinding.DisposeAsync();
         }
+
+        public Task OpenAsync()
+            => FileUploader.OpenAsync(FormElement);
     }
 }

--- a/src/Recollections.Blazor.Components/Components/FileUploadInterop.cs
+++ b/src/Recollections.Blazor.Components/Components/FileUploadInterop.cs
@@ -130,5 +130,11 @@ namespace Neptuo.Recollections.Components
             await EnsureModuleAsync();
             await module.InvokeVoidAsync("uploadUnassignedFilesTo", entityType, entityId, url);
         }
+
+        public async Task OpenAsync(ElementReference formElement)
+        {
+            await EnsureModuleAsync();
+            await module.InvokeVoidAsync("openFileDialog", formElement);
+        }
     }
 }

--- a/src/Recollections.Blazor.Components/Components/FileUploader.cs
+++ b/src/Recollections.Blazor.Components/Components/FileUploader.cs
@@ -139,4 +139,7 @@ public class FileUploader
 
     public Task UploadUnassignedFilesToAsync(string entityType, string entityId, string url)
         => interop.UploadUnassignedFilesToAsync(entityType, entityId, url);
+
+    public Task OpenAsync(ElementReference formElement)
+        => interop.OpenAsync(formElement);
 }

--- a/src/Recollections.Blazor.Components/Components/Map.razor.cs
+++ b/src/Recollections.Blazor.Components/Components/Map.razor.cs
@@ -18,10 +18,16 @@ namespace Neptuo.Recollections.Components
         public IList<MapMarkerModel> Markers { get; set; }
 
         [Parameter]
+        public string Path { get; set; }
+
+        [Parameter]
         public EventCallback MarkersChanged { get; set; }
 
         [Parameter]
         public EventCallback<int> MarkerSelected { get; set; }
+
+        [Parameter]
+        public EventCallback PathSelected { get; set; }
 
         [Parameter]
         public EventCallback OnClearLocation { get; set; }
@@ -87,7 +93,7 @@ namespace Neptuo.Recollections.Components
                 await Interop.SetViewModeAsync(ViewMode, geoJson);
             }
 
-            if (Markers.Count > 0)
+            if (Markers.Count > 0 || !String.IsNullOrEmpty(Path))
                 IsZoomed = true;
         }
 
@@ -132,6 +138,9 @@ namespace Neptuo.Recollections.Components
                 await MarkersChanged.InvokeAsync();
             }
         }
+
+        internal async Task SelectPathAsync()
+            => await PathSelected.InvokeAsync();
 
         protected async Task SearchLocationAsync()
         {

--- a/src/Recollections.Blazor.Components/Components/MapInterop.cs
+++ b/src/Recollections.Blazor.Components/Components/MapInterop.cs
@@ -34,6 +34,8 @@ namespace Neptuo.Recollections.Components
                     hashCode.Add(marker);
             }
 
+            hashCode.Add(editor.Path);
+
             return hashCode.ToHashCode();
         }
 
@@ -98,6 +100,7 @@ namespace Neptuo.Recollections.Components
                     "updateMarkers", 
                     editor.Container, 
                     editor.Markers,
+                    editor.Path,
                     editor.IsEditable
                 );
             }
@@ -140,6 +143,10 @@ namespace Neptuo.Recollections.Components
 
         [JSInvokable("MapInterop.MarkerSelected")]
         public async void MarkerSelected(int index) => await editor.MarkerSelected.InvokeAsync(index);
+
+        [JSInvokable("MapInterop.PathSelected")]
+        public async Task PathSelected()
+            => await editor.SelectPathAsync();
 
         [JSInvokable("MapInterop.MoveEnd")]
         public void MoveEnd(double latitude, double longitude, int zoom)

--- a/src/Recollections.Blazor.Components/wwwroot/FileUpload.js
+++ b/src/Recollections.Blazor.Components/wwwroot/FileUpload.js
@@ -287,6 +287,13 @@ export function bindForm(entityType, entityId, url, form, dragAndDropContainer) 
     }
 }
 
+export function openFileDialog(form) {
+    var input = form?.querySelector("input[type=file]");
+    if (input) {
+        input.click();
+    }
+}
+
 export async function getStoredFiles() {
     const storedFiles = await getStoredFilesByFlag(true);
     queue.progress.forEach(p => {

--- a/src/Recollections.Blazor.Components/wwwroot/Map.js
+++ b/src/Recollections.Blazor.Components/wwwroot/Map.js
@@ -33,7 +33,9 @@ export function initialize(container, interop, isEditable) {
             interop: interop,
             isAdditive: false,
             isEmptyPoint: false,
-            isAdding: false
+            isAdding: false,
+            trackPath: null,
+            pathPoints: []
         };
         _mapData.set(container, model);
 
@@ -109,21 +111,24 @@ export function initialize(container, interop, isEditable) {
     // }
 }
 
-export function updateMarkers(container, markers, isEditable) {
+export function updateMarkers(container, markers, path, isEditable) {
     const model = _mapData.get(container);
     
     model.lastMarkers = markers;
+    model.lastPath = path;
     model.lastIsEditable = isEditable;
 
     // In countries mode, don't show markers
     if (model.viewMode === "countries") {
+        clearTrackPath(model);
         return;
     }
 
+    setTrackPath(model, path);
     const points = setMarkers(model, markers, isEditable);
 
     model.isAdding = false;
-    model.isEmptyPoint = points.length == 0 && !model.isAdditive;
+    model.isEmptyPoint = points.length == 0 && model.pathPoints.length == 0 && !model.isAdditive;
 
     const mapEl = container.querySelector('.map');
     mapEl.style.cursor = "";
@@ -134,10 +139,11 @@ export function updateMarkers(container, markers, isEditable) {
 
 export function centerAtMarkers(container) {
     const model = _mapData.get(container);
-    if (model.points.length == 0) {
+    const points = (model.points || []).concat(model.pathPoints || []);
+    if (points.length == 0) {
         model.map.setView([0, 0], 1);
     } else {
-        model.map.fitBounds(model.points, { maxZoom: 14 });
+        model.map.fitBounds(points, { maxZoom: 14 });
     }
 }
 
@@ -223,6 +229,70 @@ function setMarkers(model, markers, isEditable) {
     return points;
 }
 
+function clearTrackPath(model) {
+    if (model.trackPath) {
+        model.trackPath.remove();
+        model.trackPath = null;
+    }
+
+    model.pathPoints = [];
+}
+
+function setTrackPath(model, path) {
+    clearTrackPath(model);
+
+    if (!path || path.length === 0) {
+        return;
+    }
+
+    const points = decodePolyline(path);
+
+    model.pathPoints = points;
+    if (points.length < 2) {
+        return;
+    }
+
+    model.trackPath = Leaflet.polyline(points, {
+        color: "#dc3545",
+        weight: 4,
+        opacity: 0.75,
+        bubblingMouseEvents: false
+    }).addTo(model.map);
+
+    model.trackPath.on("click", () => {
+        model.interop.invokeMethodAsync("MapInterop.PathSelected");
+    });
+}
+
+function decodePolyline(data) {
+    const points = [];
+    let index = 0;
+    let latitude = 0;
+    let longitude = 0;
+
+    while (index < data.length) {
+        latitude += decodeNextValue(data, () => index++);
+        longitude += decodeNextValue(data, () => index++);
+        points.push([latitude / 100000, longitude / 100000]);
+    }
+
+    return points;
+}
+
+function decodeNextValue(data, nextIndex) {
+    let result = 0;
+    let shift = 0;
+    let value;
+
+    do {
+        value = data.charCodeAt(nextIndex()) - 63;
+        result |= (value & 0x1f) << shift;
+        shift += 5;
+    } while (value >= 0x20);
+
+    return (result & 1) === 1 ? ~(result >> 1) : (result >> 1);
+}
+
 function moveMarker(model, id, latitude, longitude) {
     model.interop.invokeMethodAsync("MapInterop.MarkerMoved", id, latitude, longitude);
 }
@@ -250,6 +320,7 @@ export function setViewMode(container, mode, countriesGeoJsonString) {
                 m.remove();
             }
         }
+        clearTrackPath(model);
 
         // Remove previous countries layer
         if (model.countriesLayer) {
@@ -303,9 +374,13 @@ export function setViewMode(container, mode, countriesGeoJsonString) {
         if (model.lastMarkers && model.lastIsEditable !== undefined) {
             setMarkers(model, model.lastMarkers, model.lastIsEditable);
         }
+        if (model.lastPath) {
+            setTrackPath(model, model.lastPath);
+        }
 
-        if (model.points && model.points.length > 0) {
-            model.map.fitBounds(model.points, { maxZoom: 14 });
+        const allPoints = (model.points || []).concat(model.pathPoints || []);
+        if (allPoints.length > 0) {
+            model.map.fitBounds(allPoints, { maxZoom: 14 });
         } else {
             model.map.setView([0, 0], 1);
         }

--- a/src/Recollections.Blazor.UI/Entries/Api.cs
+++ b/src/Recollections.Blazor.UI/Entries/Api.cs
@@ -123,6 +123,8 @@ namespace Neptuo.Recollections.Entries
 
         public string MediaUploadUrl(string entryId) => $"{settings.BaseUrl}entries/{entryId}/media";
 
+        public string TrackUploadUrl(string entryId) => $"{settings.BaseUrl}entries/{entryId}/track";
+
         public Task<List<StoryListModel>> GetStoryListAsync()
             => faultHandler.Wrap(http.GetFromJsonAsync<List<StoryListModel>>("stories"));
 

--- a/src/Recollections.Blazor.UI/Entries/Components/TrackEdit.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/TrackEdit.razor
@@ -5,6 +5,12 @@
             <div class="mb-3">
                 <strong>Points:</strong> @Track.PointCount
             </div>
+            @if (Track.TotalDistance != null)
+            {
+                <div class="mb-3">
+                    <strong>Total distance:</strong> @TotalDistanceText
+                </div>
+            }
             @if (Track.TotalElevation != null)
             {
                 <div class="mb-3">

--- a/src/Recollections.Blazor.UI/Entries/Components/TrackEdit.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/TrackEdit.razor
@@ -5,6 +5,12 @@
             <div class="mb-3">
                 <strong>Points:</strong> @Track.PointCount
             </div>
+            @if (Track.TotalElevation != null)
+            {
+                <div class="mb-3">
+                    <strong>Total elevation:</strong> @TotalElevationText
+                </div>
+            }
             @if (Track.Location != null)
             {
                 <div class="mb-3">

--- a/src/Recollections.Blazor.UI/Entries/Components/TrackEdit.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/TrackEdit.razor
@@ -1,0 +1,25 @@
+<Modal @ref="Modal" Title="Track">
+    <ChildContent>
+        @if (Track != null && Track.HasValue())
+        {
+            <div class="mb-3">
+                <strong>Points:</strong> @Track.PointCount
+            </div>
+            @if (Track.Location != null)
+            {
+                <div class="mb-3">
+                    <strong>Representative location:</strong> @Track.Location.ToRoundedString()
+                </div>
+            }
+        }
+    </ChildContent>
+    <Buttons>
+        @if (IsEditable)
+        {
+            <button type="button" class="btn btn-secondary" @onclick="@Delete" title="Delete track">
+                <Icon Identifier="trash-alt" />
+                Delete
+            </button>
+        }
+    </Buttons>
+</Modal>

--- a/src/Recollections.Blazor.UI/Entries/Components/TrackEdit.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/TrackEdit.razor.cs
@@ -7,6 +7,11 @@ namespace Neptuo.Recollections.Entries.Components;
 partial class TrackEdit
 {
     protected Modal Modal { get; set; }
+    protected string TotalDistanceText => Track?.TotalDistance == null
+        ? null
+        : Track.TotalDistance.Value >= 1000d
+            ? $"{(Track.TotalDistance.Value / 1000d).ToString("0.##", CultureInfo.InvariantCulture)} km"
+            : $"{Track.TotalDistance.Value.ToString("0.#", CultureInfo.InvariantCulture)} m";
     protected string TotalElevationText => Track?.TotalElevation == null
         ? null
         : $"{Track.TotalElevation.Value.ToString("0.#", CultureInfo.InvariantCulture)} m";

--- a/src/Recollections.Blazor.UI/Entries/Components/TrackEdit.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/TrackEdit.razor.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Components;
+using Neptuo.Recollections.Components;
+
+namespace Neptuo.Recollections.Entries.Components;
+
+partial class TrackEdit
+{
+    protected Modal Modal { get; set; }
+
+    [Parameter]
+    public EntryTrackModel Track { get; set; }
+
+    [Parameter]
+    public bool IsEditable { get; set; }
+
+    [Parameter]
+    public EventCallback Delete { get; set; }
+
+    public void Show()
+    {
+        StateHasChanged();
+        Modal.Show();
+    }
+
+    public void Hide()
+        => Modal.Hide();
+}

--- a/src/Recollections.Blazor.UI/Entries/Components/TrackEdit.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/TrackEdit.razor.cs
@@ -1,11 +1,15 @@
 using Microsoft.AspNetCore.Components;
 using Neptuo.Recollections.Components;
+using System.Globalization;
 
 namespace Neptuo.Recollections.Entries.Components;
 
 partial class TrackEdit
 {
     protected Modal Modal { get; set; }
+    protected string TotalElevationText => Track?.TotalElevation == null
+        ? null
+        : $"{Track.TotalElevation.Value.ToString("0.#", CultureInfo.InvariantCulture)} m";
 
     [Parameter]
     public EntryTrackModel Track { get; set; }

--- a/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor
@@ -72,8 +72,8 @@
                 @if (UserState.IsAuthenticated)
                 {
                     <div class="gps">
-                        <MapToggle DialogTitle="@($"{Model.Title}: Map")" Text="@(MarkerCount == 0 ? "No locations..." : $"{MarkerCount} locations")" IsPlaceHolder="@(MarkerCount == 0)" IsEnabled="@(MarkerCount != 0 || Permissions.IsEditable)">
-                            <Map Markers="@Markers" MarkersChanged="@(() => SaveLocationsAsync())" IsAdditive="true" MarkerSelected="OnLocationSelected" />
+                        <MapToggle DialogTitle="@($"{Model.Title}: Map")" Text="@MapTitle" IsPlaceHolder="@(!HasMapContent)" IsEnabled="@(HasMapContent || Permissions.IsEditable)">
+                            <Map Markers="@Markers" Path="@Model.Track?.Data" MarkersChanged="@(() => SaveLocationsAsync())" IsAdditive="true" MarkerSelected="OnLocationSelected" PathSelected="OnTrackSelected" />
                         </MapToggle>
                     </div>
                 }
@@ -149,6 +149,14 @@
                             Url="@Api.MediaUploadUrl(Model.Id)"
                             DragAndDropContainer="Container"
                         />
+                        <FileUpload
+                            Text="Import GPX"
+                            EntityType="entry-track"
+                            EntityId="@EntryId"
+                            Url="@Api.TrackUploadUrl(Model.Id)"
+                            Accept=".gpx,application/gpx+xml"
+                            IsMultiple="false"
+                        />
                     </PermissionView>
                 </ActionPanel>
             </div>
@@ -156,6 +164,7 @@
     </CascadingValue>
 
     <LocationEdit @ref="LocationEdit" Save="@SaveSelectedLocationAsync" Delete="@DeleteSelectedLocationAsync" />
+    <TrackEdit @ref="TrackEdit" Track="@Model?.Track" IsEditable="@Permissions.IsEditable" Delete="@DeleteTrackAsync" />
 
     <StoryPicker @ref="StoryPicker" Selected="StorySelectedAsync" />
     <BeingPicker @ref="BeingPicker" Selected="BeingSelectedAsync" />

--- a/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor
@@ -14,6 +14,9 @@
                     {
                         <Item Icon="image" Text="Open gallery" OnClick="@(() => Gallery.OpenAsync(0))" />
                     }
+                    <PermissionView Request="@PermissionRequest.Write">
+                        <Item Icon="location-arrow" Text="Import GPX Track" OnClick="OpenTrackImportAsync" />
+                    </PermissionView>
                     <PermissionView Request="PermissionRequest.Owner">
                         <ShareButton Owner="@Owner" EntryId="@EntryId" Layout="ButtonLayout.Item" />
                     </PermissionView>
@@ -150,12 +153,14 @@
                             DragAndDropContainer="Container"
                         />
                         <FileUpload
+                            @ref="TrackUpload"
                             Text="Import GPX"
                             EntityType="entry-track"
                             EntityId="@EntryId"
                             Url="@Api.TrackUploadUrl(Model.Id)"
                             Accept=".gpx,application/gpx+xml"
                             IsMultiple="false"
+                            CssClass="d-none"
                         />
                     </PermissionView>
                 </ActionPanel>

--- a/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor.cs
@@ -95,6 +95,7 @@ namespace Neptuo.Recollections.Entries.Pages
         protected List<FileUploadProgress> UploadProgress { get; } = [];
         protected PermissionContainerState Permissions { get; } = new PermissionContainerState();
         protected Gallery Gallery { get; set; }
+        protected FileUpload TrackUpload { get; set; }
         protected List<GalleryModel> GalleryItems { get; } = new List<GalleryModel>();
 
         public override Task SetParametersAsync(ParameterView parameters)
@@ -285,6 +286,9 @@ namespace Neptuo.Recollections.Entries.Pages
             else if (item.Video != null)
                 Navigator.OpenVideoDetail(EntryId, item.Video.Id);
         }
+
+        protected Task OpenTrackImportAsync()
+            => TrackUpload?.OpenAsync() ?? Task.CompletedTask;
 
         protected async Task SaveTitleAsync(string value)
         {

--- a/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor.cs
@@ -42,6 +42,7 @@ namespace Neptuo.Recollections.Entries.Pages
         protected FileUploader FileUploader { get; set; }
 
         private IDisposable previousUploadListener;
+        private IDisposable previousTrackUploadListener;
         private string previousEntryId;
 
         [Parameter]
@@ -74,6 +75,23 @@ namespace Neptuo.Recollections.Entries.Pages
         }
         protected List<MapMarkerModel> Markers { get; } = new List<MapMarkerModel>();
         protected int MarkerCount => Markers.Count(m => m.Longitude != null && m.Latitude != null);
+        protected int TrackPointCount => Model?.Track?.PointCount ?? 0;
+        protected bool HasTrack => Model?.Track?.HasValue() == true;
+        protected bool HasMapContent => MarkerCount > 0 || HasTrack;
+        protected string MapTitle
+        {
+            get
+            {
+                if (HasTrack && MarkerCount > 0)
+                    return $"Track and {MarkerCount} locations";
+                else if (HasTrack)
+                    return $"Track ({TrackPointCount} points)";
+                else if (MarkerCount > 0)
+                    return $"{MarkerCount} locations";
+                else
+                    return "No locations...";
+            }
+        }
         protected List<FileUploadProgress> UploadProgress { get; } = [];
         protected PermissionContainerState Permissions { get; } = new PermissionContainerState();
         protected Gallery Gallery { get; set; }
@@ -96,12 +114,15 @@ namespace Neptuo.Recollections.Entries.Pages
 
                 previousUploadListener?.Dispose();
                 previousUploadListener = FileUploader.AddProgressListener("entry", EntryId, (progresses) => _ = OnUploadProgressAsync(progresses));
+                previousTrackUploadListener?.Dispose();
+                previousTrackUploadListener = FileUploader.AddProgressListener("entry-track", EntryId, (progresses) => _ = OnTrackUploadProgressAsync(progresses));
             }
         }
         
         public void Dispose()
         {
             previousUploadListener?.Dispose();
+            previousTrackUploadListener?.Dispose();
         }
 
         private async Task LoadStoryAsync()
@@ -374,6 +395,17 @@ namespace Neptuo.Recollections.Entries.Pages
             StateHasChanged();
         }
 
+        protected async Task OnTrackUploadProgressAsync(IReadOnlyCollection<FileUploadProgress> progresses)
+        {
+            if (progresses.All(p => p.Status == "done" || p.Status == "error"))
+            {
+                if (progresses.Any(p => p.IsDone))
+                    await LoadAsync();
+
+                StateHasChanged();
+            }
+        }
+
         public async Task DeleteAsync()
         {
             if (await Navigator.AskAsync($"Do you really want to delete entry '{Model.Title}'?"))
@@ -386,6 +418,7 @@ namespace Neptuo.Recollections.Entries.Pages
         protected int SelectedLocationIndex { get; set; }
         protected LocationModel SelectedLocation { get; set; }
         protected LocationEdit LocationEdit { get; set; }
+        protected TrackEdit TrackEdit { get; set; }
 
         protected void OnLocationSelected(int index)
         {
@@ -430,6 +463,23 @@ namespace Neptuo.Recollections.Entries.Pages
             Markers.RemoveAt(SelectedLocationIndex + Media.Count);
             LocationEdit.Hide();
             await SaveAsync();
+        }
+
+        protected void OnTrackSelected()
+        {
+            if (Model?.Track?.HasValue() == true)
+            {
+                TrackEdit.Show();
+                StateHasChanged();
+            }
+        }
+
+        protected async Task DeleteTrackAsync()
+        {
+            Model.Track = new EntryTrackModel();
+            TrackEdit.Hide();
+            await SaveAsync();
+            await LoadAsync();
         }
 
         protected Task SaveSelectedLocationAsync(LocationModel model)

--- a/src/Recollections.Entries.Azure/AzureFileStorage.cs
+++ b/src/Recollections.Entries.Azure/AzureFileStorage.cs
@@ -47,6 +47,50 @@ namespace Neptuo.Recollections.Entries
             return entryDirectory;
         }
 
+        private static string GetFileName(EntryFileType type)
+            => type switch
+            {
+                EntryFileType.Track => "track.gpx",
+                _ => throw Ensure.Exception.NotSupported(type)
+            };
+
+        private async Task<ShareFileClient> GetFileAsync(Entry entry, EntryFileType type)
+        {
+            ShareDirectoryClient entryDirectory = await GetDirectoryAsync(entry);
+            string fileName = GetFileName(type);
+            return entryDirectory.GetFileClient(fileName);
+        }
+
+        public async Task<Stream> FindAsync(Entry entry, EntryFileType type)
+        {
+            ShareFileClient file = await GetFileAsync(entry, type);
+            if (await file.ExistsAsync())
+            {
+                ShareFileDownloadInfo download = await file.DownloadAsync();
+                return download.Content;
+            }
+
+            return null;
+        }
+
+        public async Task SaveAsync(Entry entry, Stream content, EntryFileType type)
+        {
+            ShareFileClient file = await GetFileAsync(entry, type);
+            await file.DeleteIfExistsAsync();
+            await file.CreateAsync(content.Length);
+
+            if (content.CanSeek)
+                content.Position = 0;
+
+            await file.UploadAsync(content);
+        }
+
+        public async Task DeleteAsync(Entry entry, EntryFileType type)
+        {
+            ShareFileClient file = await GetFileAsync(entry, type);
+            await file.DeleteIfExistsAsync();
+        }
+
         private string GetImageFileName(Image image, ImageType type)
         {
             string AddSuffix(string name, string suffix)

--- a/src/Recollections.Entries.Data/Entry.cs
+++ b/src/Recollections.Entries.Data/Entry.cs
@@ -24,6 +24,11 @@ namespace Neptuo.Recollections.Entries
         public StoryChapter Chapter { get; set; }
 
         public IList<OrderedLocation> Locations { get; set; } = new List<OrderedLocation>();
+        public string TrackData { get; set; }
+        public int? TrackPointCount { get; set; }
+        public double? TrackLatitude { get; set; }
+        public double? TrackLongitude { get; set; }
+        public double? TrackAltitude { get; set; }
         public IList<Being> Beings { get; set; } = new List<Being>();
 
         public DateTime When { get; set; }

--- a/src/Recollections.Entries.Data/Entry.cs
+++ b/src/Recollections.Entries.Data/Entry.cs
@@ -27,6 +27,7 @@ namespace Neptuo.Recollections.Entries
         public string TrackData { get; set; }
         public int? TrackPointCount { get; set; }
         public double? TrackTotalElevation { get; set; }
+        public double? TrackTotalDistance { get; set; }
         public double? TrackLatitude { get; set; }
         public double? TrackLongitude { get; set; }
         public double? TrackAltitude { get; set; }

--- a/src/Recollections.Entries.Data/Entry.cs
+++ b/src/Recollections.Entries.Data/Entry.cs
@@ -26,6 +26,7 @@ namespace Neptuo.Recollections.Entries
         public IList<OrderedLocation> Locations { get; set; } = new List<OrderedLocation>();
         public string TrackData { get; set; }
         public int? TrackPointCount { get; set; }
+        public double? TrackTotalElevation { get; set; }
         public double? TrackLatitude { get; set; }
         public double? TrackLongitude { get; set; }
         public double? TrackAltitude { get; set; }

--- a/src/Recollections.Entries.Data/Migrations/20260414135907_EntryTrackBlob.Designer.cs
+++ b/src/Recollections.Entries.Data/Migrations/20260414135907_EntryTrackBlob.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Neptuo.Recollections.Entries;
 
@@ -10,9 +11,11 @@ using Neptuo.Recollections.Entries;
 namespace Neptuo.Recollections.Entries.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260414135907_EntryTrackBlob")]
+    partial class EntryTrackBlob
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.0");

--- a/src/Recollections.Entries.Data/Migrations/20260414135907_EntryTrackBlob.cs
+++ b/src/Recollections.Entries.Data/Migrations/20260414135907_EntryTrackBlob.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Neptuo.Recollections.Entries.Migrations
+{
+    /// <inheritdoc />
+    public partial class EntryTrackBlob : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "TrackAltitude",
+                table: "Entries",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TrackData",
+                table: "Entries",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "TrackLatitude",
+                table: "Entries",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "TrackLongitude",
+                table: "Entries",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TrackPointCount",
+                table: "Entries",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TrackAltitude",
+                table: "Entries");
+
+            migrationBuilder.DropColumn(
+                name: "TrackData",
+                table: "Entries");
+
+            migrationBuilder.DropColumn(
+                name: "TrackLatitude",
+                table: "Entries");
+
+            migrationBuilder.DropColumn(
+                name: "TrackLongitude",
+                table: "Entries");
+
+            migrationBuilder.DropColumn(
+                name: "TrackPointCount",
+                table: "Entries");
+        }
+    }
+}

--- a/src/Recollections.Entries.Data/Migrations/20260415073308_EntryTrackTotalElevation.Designer.cs
+++ b/src/Recollections.Entries.Data/Migrations/20260415073308_EntryTrackTotalElevation.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Neptuo.Recollections.Entries;
 
@@ -10,9 +11,11 @@ using Neptuo.Recollections.Entries;
 namespace Neptuo.Recollections.Entries.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260415073308_EntryTrackTotalElevation")]
+    partial class EntryTrackTotalElevation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.0");

--- a/src/Recollections.Entries.Data/Migrations/20260415073308_EntryTrackTotalElevation.cs
+++ b/src/Recollections.Entries.Data/Migrations/20260415073308_EntryTrackTotalElevation.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Neptuo.Recollections.Entries.Migrations
+{
+    /// <inheritdoc />
+    public partial class EntryTrackTotalElevation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "TrackTotalElevation",
+                table: "Entries",
+                type: "REAL",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TrackTotalElevation",
+                table: "Entries");
+        }
+    }
+}

--- a/src/Recollections.Entries.Data/Migrations/20260415084331_EntryTrackTotalDistance.Designer.cs
+++ b/src/Recollections.Entries.Data/Migrations/20260415084331_EntryTrackTotalDistance.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Neptuo.Recollections.Entries;
 
@@ -10,9 +11,11 @@ using Neptuo.Recollections.Entries;
 namespace Neptuo.Recollections.Entries.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260415084331_EntryTrackTotalDistance")]
+    partial class EntryTrackTotalDistance
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.0");

--- a/src/Recollections.Entries.Data/Migrations/20260415084331_EntryTrackTotalDistance.cs
+++ b/src/Recollections.Entries.Data/Migrations/20260415084331_EntryTrackTotalDistance.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Neptuo.Recollections.Entries.Migrations
+{
+    /// <inheritdoc />
+    public partial class EntryTrackTotalDistance : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "TrackTotalDistance",
+                table: "Entries",
+                type: "REAL",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TrackTotalDistance",
+                table: "Entries");
+        }
+    }
+}

--- a/src/Recollections.Entries.Models/EntryTrackModel.cs
+++ b/src/Recollections.Entries.Models/EntryTrackModel.cs
@@ -8,6 +8,7 @@ namespace Neptuo.Recollections.Entries
         public string Data { get; set; }
         public int PointCount { get; set; }
         public double? TotalElevation { get; set; }
+        public double? TotalDistance { get; set; }
         public LocationModel Location { get; set; }
 
         public bool HasValue()
@@ -19,6 +20,7 @@ namespace Neptuo.Recollections.Entries
                 Data = Data,
                 PointCount = PointCount,
                 TotalElevation = TotalElevation,
+                TotalDistance = TotalDistance,
                 Location = Location?.Clone()
             };
 
@@ -30,9 +32,10 @@ namespace Neptuo.Recollections.Entries
                 && Data == other.Data
                 && PointCount == other.PointCount
                 && TotalElevation == other.TotalElevation
+                && TotalDistance == other.TotalDistance
                 && EqualityComparer<LocationModel>.Default.Equals(Location, other.Location);
 
         public override int GetHashCode()
-            => HashCode.Combine(Data, PointCount, TotalElevation, Location);
+            => HashCode.Combine(Data, PointCount, TotalElevation, TotalDistance, Location);
     }
 }

--- a/src/Recollections.Entries.Models/EntryTrackModel.cs
+++ b/src/Recollections.Entries.Models/EntryTrackModel.cs
@@ -7,6 +7,7 @@ namespace Neptuo.Recollections.Entries
     {
         public string Data { get; set; }
         public int PointCount { get; set; }
+        public double? TotalElevation { get; set; }
         public LocationModel Location { get; set; }
 
         public bool HasValue()
@@ -17,6 +18,7 @@ namespace Neptuo.Recollections.Entries
             {
                 Data = Data,
                 PointCount = PointCount,
+                TotalElevation = TotalElevation,
                 Location = Location?.Clone()
             };
 
@@ -27,9 +29,10 @@ namespace Neptuo.Recollections.Entries
             => other != null
                 && Data == other.Data
                 && PointCount == other.PointCount
+                && TotalElevation == other.TotalElevation
                 && EqualityComparer<LocationModel>.Default.Equals(Location, other.Location);
 
         public override int GetHashCode()
-            => HashCode.Combine(Data, PointCount, Location);
+            => HashCode.Combine(Data, PointCount, TotalElevation, Location);
     }
 }

--- a/src/Recollections.Entries.Models/EntryTrackModel.cs
+++ b/src/Recollections.Entries.Models/EntryTrackModel.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace Neptuo.Recollections.Entries
+{
+    public class EntryTrackModel : ICloneable<EntryTrackModel>, IEquatable<EntryTrackModel>
+    {
+        public string Data { get; set; }
+        public int PointCount { get; set; }
+        public LocationModel Location { get; set; }
+
+        public bool HasValue()
+            => !String.IsNullOrEmpty(Data) && PointCount > 0;
+
+        public EntryTrackModel Clone()
+            => new EntryTrackModel()
+            {
+                Data = Data,
+                PointCount = PointCount,
+                Location = Location?.Clone()
+            };
+
+        public override bool Equals(object obj)
+            => Equals(obj as EntryTrackModel);
+
+        public bool Equals(EntryTrackModel other)
+            => other != null
+                && Data == other.Data
+                && PointCount == other.PointCount
+                && EqualityComparer<LocationModel>.Default.Equals(Location, other.Location);
+
+        public override int GetHashCode()
+            => HashCode.Combine(Data, PointCount, Location);
+    }
+}

--- a/src/Recollections.Entries.SystemIo/SystemIoFileStorage.cs
+++ b/src/Recollections.Entries.SystemIo/SystemIoFileStorage.cs
@@ -39,6 +39,43 @@ namespace Neptuo.Recollections.Entries
             return storagePath;
         }
 
+        private string GetFilePath(Entry entry, EntryFileType type)
+        {
+            string fileName = type switch
+            {
+                EntryFileType.Track => "track.gpx",
+                _ => throw Ensure.Exception.NotSupported(type)
+            };
+
+            return Path.Combine(GetStoragePath(entry), fileName);
+        }
+
+        public Task<Stream> FindAsync(Entry entry, EntryFileType type)
+        {
+            string filePath = GetFilePath(entry, type);
+            if (!File.Exists(filePath))
+                return Task.FromResult<Stream>(null);
+
+            return Task.FromResult<Stream>(new FileStream(filePath, FileMode.Open, FileAccess.Read));
+        }
+
+        public async Task SaveAsync(Entry entry, Stream content, EntryFileType type)
+        {
+            string filePath = GetFilePath(entry, type);
+            if (content.CanSeek)
+                content.Position = 0;
+
+            using FileStream target = File.Create(filePath);
+            await content.CopyToAsync(target);
+        }
+
+        public Task DeleteAsync(Entry entry, EntryFileType type)
+        {
+            string filePath = GetFilePath(entry, type);
+            File.Delete(filePath);
+            return Task.CompletedTask;
+        }
+
         public Task<Stream> FindAsync(Entry entry, Image image, ImageType type)
         {
             ImagePath path = GetPath(entry, image);

--- a/src/Recollections.Entries/GpxImportService.cs
+++ b/src/Recollections.Entries/GpxImportService.cs
@@ -12,6 +12,7 @@ namespace Neptuo.Recollections.Entries
     public class GpxImportService
     {
         public const int MaxLocationCount = 250;
+        private const double EarthRadius = 6371000d;
 
         public EntryTrackModel Parse(IFileInput input)
         {
@@ -63,6 +64,7 @@ namespace Neptuo.Recollections.Entries
                 Data = Encode(simplified),
                 PointCount = simplified.Count,
                 TotalElevation = CalculateTotalElevation(normalized),
+                TotalDistance = CalculateTotalDistance(normalized),
                 Location = simplified[simplified.Count / 2].Clone()
             };
         }
@@ -256,5 +258,40 @@ namespace Neptuo.Recollections.Entries
 
             return Math.Round(total, 1, MidpointRounding.AwayFromZero);
         }
+
+        private static double CalculateTotalDistance(IReadOnlyList<LocationModel> locations)
+        {
+            double total = 0;
+            for (int i = 1; i < locations.Count; i++)
+                total += CalculateDistance(locations[i - 1], locations[i]);
+
+            return Math.Round(total, 1, MidpointRounding.AwayFromZero);
+        }
+
+        private static double CalculateDistance(LocationModel previous, LocationModel current)
+        {
+            double latitude1 = ToRadians(previous.Latitude.Value);
+            double latitude2 = ToRadians(current.Latitude.Value);
+            double latitudeDelta = latitude2 - latitude1;
+            double longitudeDelta = ToRadians(current.Longitude.Value - previous.Longitude.Value);
+
+            double a =
+                Math.Pow(Math.Sin(latitudeDelta / 2d), 2d) +
+                Math.Cos(latitude1) * Math.Cos(latitude2) * Math.Pow(Math.Sin(longitudeDelta / 2d), 2d);
+            a = Math.Min(1d, a);
+            double c = 2d * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1d - a));
+            double horizontalDistance = EarthRadius * c;
+
+            if (previous.Altitude != null && current.Altitude != null)
+            {
+                double altitudeDelta = current.Altitude.Value - previous.Altitude.Value;
+                return Math.Sqrt((horizontalDistance * horizontalDistance) + (altitudeDelta * altitudeDelta));
+            }
+
+            return horizontalDistance;
+        }
+
+        private static double ToRadians(double degrees)
+            => degrees * (Math.PI / 180d);
     }
 }

--- a/src/Recollections.Entries/GpxImportService.cs
+++ b/src/Recollections.Entries/GpxImportService.cs
@@ -1,0 +1,194 @@
+using Neptuo;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Neptuo.Recollections.Entries
+{
+    public class GpxImportService
+    {
+        public const int MaxLocationCount = 250;
+
+        public EntryTrackModel Parse(IFileInput input)
+        {
+            Ensure.NotNull(input, "input");
+
+            string extension = Path.GetExtension(input.FileName);
+            if (!String.Equals(extension, ".gpx", StringComparison.OrdinalIgnoreCase))
+                throw new TrackImportValidationException();
+
+            try
+            {
+                using Stream stream = input.OpenReadStream();
+                XDocument document = XDocument.Load(stream);
+
+                List<LocationModel> result = document
+                    .Descendants()
+                    .Where(e => e.Name.LocalName == "trkpt" || e.Name.LocalName == "rtept")
+                    .Select(MapLocation)
+                    .Where(l => l != null && l.HasValue())
+                    .ToList();
+
+                if (result.Count == 0)
+                    throw new TrackImportValidationException();
+
+                return Create(result);
+            }
+            catch (XmlException)
+            {
+                throw new TrackImportValidationException();
+            }
+        }
+
+        public EntryTrackModel Create(IReadOnlyList<LocationModel> locations)
+        {
+            Ensure.NotNull(locations, "locations");
+
+            IReadOnlyList<LocationModel> simplified = Simplify(locations);
+            if (simplified.Count == 0)
+                throw new TrackImportValidationException();
+
+            return new EntryTrackModel()
+            {
+                Data = Encode(simplified),
+                PointCount = simplified.Count,
+                Location = simplified[simplified.Count / 2].Clone()
+            };
+        }
+
+        public IReadOnlyList<LocationModel> Decode(string data)
+        {
+            if (String.IsNullOrEmpty(data))
+                return [];
+
+            List<LocationModel> result = [];
+            int index = 0;
+            int latitude = 0;
+            int longitude = 0;
+
+            while (index < data.Length)
+            {
+                latitude += DecodeNextCoordinate(data, ref index);
+                longitude += DecodeNextCoordinate(data, ref index);
+
+                result.Add(new LocationModel()
+                {
+                    Latitude = latitude / 100000d,
+                    Longitude = longitude / 100000d
+                });
+            }
+
+            return result;
+        }
+
+        private static LocationModel MapLocation(XElement element)
+        {
+            if (!TryParseDouble(element.Attribute("lat")?.Value, out double latitude))
+                return null;
+
+            if (!TryParseDouble(element.Attribute("lon")?.Value, out double longitude))
+                return null;
+
+            double? altitude = null;
+            XElement altitudeElement = element.Elements().FirstOrDefault(e => e.Name.LocalName == "ele");
+            if (altitudeElement != null && TryParseDouble(altitudeElement.Value, out double altitudeValue))
+                altitude = altitudeValue;
+
+            return new LocationModel()
+            {
+                Latitude = latitude,
+                Longitude = longitude,
+                Altitude = altitude
+            };
+        }
+
+        private static bool TryParseDouble(string value, out double result)
+            => Double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+
+        private static string Encode(IReadOnlyList<LocationModel> locations)
+        {
+            var builder = new System.Text.StringBuilder();
+            int previousLatitude = 0;
+            int previousLongitude = 0;
+
+            foreach (var location in locations)
+            {
+                int latitude = (int)Math.Round(location.Latitude.Value * 100000d, MidpointRounding.AwayFromZero);
+                int longitude = (int)Math.Round(location.Longitude.Value * 100000d, MidpointRounding.AwayFromZero);
+
+                EncodeCoordinate(builder, latitude - previousLatitude);
+                EncodeCoordinate(builder, longitude - previousLongitude);
+
+                previousLatitude = latitude;
+                previousLongitude = longitude;
+            }
+
+            return builder.ToString();
+        }
+
+        private static void EncodeCoordinate(System.Text.StringBuilder builder, int value)
+        {
+            value = value < 0 ? ~(value << 1) : (value << 1);
+
+            while (value >= 0x20)
+            {
+                builder.Append((char)((0x20 | (value & 0x1f)) + 63));
+                value >>= 5;
+            }
+
+            builder.Append((char)(value + 63));
+        }
+
+        private static int DecodeNextCoordinate(string data, ref int index)
+        {
+            int result = 0;
+            int shift = 0;
+            int value;
+
+            do
+            {
+                value = data[index++] - 63;
+                result |= (value & 0x1f) << shift;
+                shift += 5;
+            }
+            while (value >= 0x20 && index < data.Length);
+
+            return (result & 1) == 1 ? ~(result >> 1) : (result >> 1);
+        }
+
+        private static IReadOnlyList<LocationModel> Simplify(IReadOnlyList<LocationModel> locations)
+        {
+            List<LocationModel> uniqueLocations = new List<LocationModel>(locations.Count);
+            foreach (var location in locations)
+            {
+                if (uniqueLocations.Count == 0 || !uniqueLocations[uniqueLocations.Count - 1].Equals(location))
+                    uniqueLocations.Add(location);
+            }
+
+            if (uniqueLocations.Count <= MaxLocationCount)
+                return uniqueLocations;
+
+            List<LocationModel> result = new List<LocationModel>(MaxLocationCount);
+            double step = (uniqueLocations.Count - 1d) / (MaxLocationCount - 1d);
+            for (int i = 0; i < MaxLocationCount; i++)
+            {
+                int index = (int)Math.Round(i * step, MidpointRounding.AwayFromZero);
+                index = Math.Min(index, uniqueLocations.Count - 1);
+
+                LocationModel location = uniqueLocations[index];
+                if (result.Count == 0 || !result[result.Count - 1].Equals(location))
+                    result.Add(location.Clone());
+            }
+
+            LocationModel last = uniqueLocations[uniqueLocations.Count - 1];
+            if (!result[result.Count - 1].Equals(last))
+                result[result.Count - 1] = last.Clone();
+
+            return result;
+        }
+    }
+}

--- a/src/Recollections.Entries/GpxImportService.cs
+++ b/src/Recollections.Entries/GpxImportService.cs
@@ -38,7 +38,11 @@ namespace Neptuo.Recollections.Entries
 
                 return Create(result);
             }
-            catch (XmlException)
+            catch (TrackImportValidationException)
+            {
+                throw;
+            }
+            catch (Exception ex) when (ex is XmlException || ex is IOException || ex is InvalidOperationException)
             {
                 throw new TrackImportValidationException();
             }
@@ -47,6 +51,7 @@ namespace Neptuo.Recollections.Entries
         public EntryTrackModel Create(IReadOnlyList<LocationModel> locations)
         {
             Ensure.NotNull(locations, "locations");
+            EnsureHasCoordinates(locations);
 
             IReadOnlyList<LocationModel> simplified = Simplify(locations);
             if (simplified.Count == 0)
@@ -108,6 +113,12 @@ namespace Neptuo.Recollections.Entries
 
         private static bool TryParseDouble(string value, out double result)
             => Double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+
+        private static void EnsureHasCoordinates(IReadOnlyList<LocationModel> locations)
+        {
+            if (locations.Any(l => l == null || !l.HasValue()))
+                throw new TrackImportValidationException();
+        }
 
         private static string Encode(IReadOnlyList<LocationModel> locations)
         {

--- a/src/Recollections.Entries/GpxImportService.cs
+++ b/src/Recollections.Entries/GpxImportService.cs
@@ -79,8 +79,14 @@ namespace Neptuo.Recollections.Entries
 
             while (index < data.Length)
             {
-                latitude += DecodeNextCoordinate(data, ref index);
-                longitude += DecodeNextCoordinate(data, ref index);
+                if (!TryDecodeNextCoordinate(data, ref index, out int latitudeDelta))
+                    return [];
+
+                if (!TryDecodeNextCoordinate(data, ref index, out int longitudeDelta))
+                    return [];
+
+                latitude += latitudeDelta;
+                longitude += longitudeDelta;
 
                 result.Add(new LocationModel()
                 {
@@ -156,21 +162,32 @@ namespace Neptuo.Recollections.Entries
             builder.Append((char)(value + 63));
         }
 
-        private static int DecodeNextCoordinate(string data, ref int index)
+        private static bool TryDecodeNextCoordinate(string data, ref int index, out int coordinate)
         {
+            coordinate = 0;
+            if (index >= data.Length)
+                return false;
+
             int result = 0;
             int shift = 0;
-            int value;
-
-            do
+            while (true)
             {
-                value = data[index++] - 63;
+                if (index >= data.Length)
+                    return false;
+
+                int value = data[index++] - 63;
+                if (value < 0)
+                    return false;
+
                 result |= (value & 0x1f) << shift;
                 shift += 5;
-            }
-            while (value >= 0x20 && index < data.Length);
 
-            return (result & 1) == 1 ? ~(result >> 1) : (result >> 1);
+                if (value < 0x20)
+                    break;
+            }
+
+            coordinate = (result & 1) == 1 ? ~(result >> 1) : (result >> 1);
+            return true;
         }
 
         private static IReadOnlyList<LocationModel> Simplify(IReadOnlyList<LocationModel> locations)

--- a/src/Recollections.Entries/GpxImportService.cs
+++ b/src/Recollections.Entries/GpxImportService.cs
@@ -53,7 +53,8 @@ namespace Neptuo.Recollections.Entries
             Ensure.NotNull(locations, "locations");
             EnsureHasCoordinates(locations);
 
-            IReadOnlyList<LocationModel> simplified = Simplify(locations);
+            IReadOnlyList<LocationModel> normalized = Normalize(locations);
+            IReadOnlyList<LocationModel> simplified = Simplify(normalized);
             if (simplified.Count == 0)
                 throw new TrackImportValidationException();
 
@@ -61,6 +62,7 @@ namespace Neptuo.Recollections.Entries
             {
                 Data = Encode(simplified),
                 PointCount = simplified.Count,
+                TotalElevation = CalculateTotalElevation(normalized),
                 Location = simplified[simplified.Count / 2].Clone()
             };
         }
@@ -173,12 +175,7 @@ namespace Neptuo.Recollections.Entries
 
         private static IReadOnlyList<LocationModel> Simplify(IReadOnlyList<LocationModel> locations)
         {
-            List<LocationModel> uniqueLocations = new List<LocationModel>(locations.Count);
-            foreach (var location in locations)
-            {
-                if (uniqueLocations.Count == 0 || !uniqueLocations[uniqueLocations.Count - 1].Equals(location))
-                    uniqueLocations.Add(location);
-            }
+            IReadOnlyList<LocationModel> uniqueLocations = Normalize(locations);
 
             if (uniqueLocations.Count <= MaxLocationCount)
                 return uniqueLocations;
@@ -200,6 +197,47 @@ namespace Neptuo.Recollections.Entries
                 result[result.Count - 1] = last.Clone();
 
             return result;
+        }
+
+        private static IReadOnlyList<LocationModel> Normalize(IReadOnlyList<LocationModel> locations)
+        {
+            List<LocationModel> uniqueLocations = new List<LocationModel>(locations.Count);
+            foreach (var location in locations)
+            {
+                if (uniqueLocations.Count == 0 || !uniqueLocations[uniqueLocations.Count - 1].Equals(location))
+                    uniqueLocations.Add(location.Clone());
+            }
+
+            return uniqueLocations;
+        }
+
+        private static double? CalculateTotalElevation(IReadOnlyList<LocationModel> locations)
+        {
+            double total = 0;
+            double? previousAltitude = null;
+            bool hasAltitude = false;
+
+            foreach (var location in locations)
+            {
+                if (location?.Altitude == null)
+                    continue;
+
+                hasAltitude = true;
+                double currentAltitude = location.Altitude.Value;
+                if (previousAltitude != null)
+                {
+                    double delta = currentAltitude - previousAltitude.Value;
+                    if (delta > 0)
+                        total += delta;
+                }
+
+                previousAltitude = currentAltitude;
+            }
+
+            if (!hasAltitude)
+                return null;
+
+            return Math.Round(total, 1, MidpointRounding.AwayFromZero);
         }
     }
 }

--- a/src/Recollections.Entries/GpxImportService.cs
+++ b/src/Recollections.Entries/GpxImportService.cs
@@ -194,24 +194,22 @@ namespace Neptuo.Recollections.Entries
 
         private static IReadOnlyList<LocationModel> Simplify(IReadOnlyList<LocationModel> locations)
         {
-            IReadOnlyList<LocationModel> uniqueLocations = Normalize(locations);
-
-            if (uniqueLocations.Count <= MaxLocationCount)
-                return uniqueLocations;
+            if (locations.Count <= MaxLocationCount)
+                return locations;
 
             List<LocationModel> result = new List<LocationModel>(MaxLocationCount);
-            double step = (uniqueLocations.Count - 1d) / (MaxLocationCount - 1d);
+            double step = (locations.Count - 1d) / (MaxLocationCount - 1d);
             for (int i = 0; i < MaxLocationCount; i++)
             {
                 int index = (int)Math.Round(i * step, MidpointRounding.AwayFromZero);
-                index = Math.Min(index, uniqueLocations.Count - 1);
+                index = Math.Min(index, locations.Count - 1);
 
-                LocationModel location = uniqueLocations[index];
+                LocationModel location = locations[index];
                 if (result.Count == 0 || !result[result.Count - 1].Equals(location))
                     result.Add(location.Clone());
             }
 
-            LocationModel last = uniqueLocations[uniqueLocations.Count - 1];
+            LocationModel last = locations[locations.Count - 1];
             if (!result[result.Count - 1].Equals(last))
                 result[result.Count - 1] = last.Clone();
 

--- a/src/Recollections.Entries/IFileStorage.cs
+++ b/src/Recollections.Entries/IFileStorage.cs
@@ -7,9 +7,18 @@ using System.Threading.Tasks;
 
 namespace Neptuo.Recollections.Entries
 {
+    public enum EntryFileType
+    {
+        Track
+    }
+
     public interface IFileStorage
     {
         bool CanStreamSeek { get; }
+
+        Task<Stream> FindAsync(Entry entry, EntryFileType type);
+        Task SaveAsync(Entry entry, Stream content, EntryFileType type);
+        Task DeleteAsync(Entry entry, EntryFileType type);
 
         Task<Stream> FindAsync(Entry entry, Image image, ImageType type);
         Task SaveAsync(Entry entry, Image image, Stream content, ImageType type);

--- a/src/Recollections.Entries/TrackImportValidationException.cs
+++ b/src/Recollections.Entries/TrackImportValidationException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Neptuo.Recollections.Entries
+{
+    public class TrackImportValidationException : Exception
+    {
+        public TrackImportValidationException()
+            : base("The uploaded GPX file doesn't contain a valid track.")
+        { }
+    }
+}


### PR DESCRIPTION
Fixes #91 
Fixes #90

This adds first-class GPX track support for entries so imported bike or activity routes stay usable on the map without flooding the UI with hundreds of pins.

## Summary

- import `.gpx` files into a condensed stored track format optimized for map rendering and storage size
- render entry tracks as a path on the map instead of one marker per imported point
- keep manually added entry locations intact when a track is imported
- use a cached representative coordinate as a fallback for the all-entries map when the track is the only location source
- add a track details modal on path click, including delete support for editable entries
- cover the API and map behavior with regression tests

## Notes for reviewers

The main design change here is storing imported tracks separately from manual locations. That keeps manual pins editable while letting GPX data stay compact and readable in the UI.

I would especially appreciate review on the condensed track encoding/decoding and the entry map interaction flow.