### PR TITLE
Upgrade Aspire AppHost SDK to 13.2.2

### DIFF
--- a/src/AppHost.cs
+++ b/src/AppHost.cs
@@ -1,4 +1,4 @@
-#:sdk Aspire.AppHost.Sdk@13.0.2
+#:sdk Aspire.AppHost.Sdk@13.2.2
 #:project .\Recollections.Api\Recollections.Api.csproj
 #:project .\Recollections.Blazor.UI\Recollections.Blazor.UI.csproj
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-	<FrameworkPackageVersion>10.0.0</FrameworkPackageVersion>
+	<FrameworkPackageVersion>10.0.6</FrameworkPackageVersion>
   </PropertyGroup>
   <ItemGroup>
 	<!-- Transitive dependencies -->


### PR DESCRIPTION
Upgrades the Aspire AppHost SDK from 13.0.2 to the latest 13.2.2 release, picking up bug fixes, platform improvements, and CLI enhancements shipped in the 13.2.x line.

Aspire 13.2.2 requires `Microsoft.Extensions.*` packages at >= 10.0.5, which conflicted with the centrally managed `FrameworkPackageVersion` of 10.0.0. This PR bumps `FrameworkPackageVersion` to 10.0.6 (the latest .NET 10 patch) to resolve the transitive pinning downgrades.

**Changes:**
- `src/AppHost.cs` -- SDK directive `13.0.2` -> `13.2.2`
- `src/Directory.Packages.props` -- `FrameworkPackageVersion` `10.0.0` -> `10.0.6`