### PR TITLE
Refactor HighestAltitudeService to mapper pattern

### DIFF
--- a/src/Recollections.Api/Entries/Controllers/BeingEntriesController.cs
+++ b/src/Recollections.Api/Entries/Controllers/BeingEntriesController.cs
@@ -23,23 +23,23 @@ namespace Neptuo.Recollections.Entries.Controllers
         private readonly ShareStatusService shareStatus;
         private readonly EntryListMapper entryMapper;
         private readonly StoryListMapper storyMapper;
-        private readonly HighestAltitudeService highestAltitudeService;
+        private readonly HighestAltitudeMapper highestAltitudeMapper;
         private readonly IConnectionProvider connections;
 
-        public BeingEntriesController(DataContext db, ShareStatusService shareStatus, EntryListMapper entryMapper, StoryListMapper storyMapper, HighestAltitudeService highestAltitudeService, IConnectionProvider connections)
+        public BeingEntriesController(DataContext db, ShareStatusService shareStatus, EntryListMapper entryMapper, StoryListMapper storyMapper, HighestAltitudeMapper highestAltitudeMapper, IConnectionProvider connections)
             : base(db, shareStatus)
         {
             Ensure.NotNull(db, "db");
             Ensure.NotNull(shareStatus, "shareStatus");
             Ensure.NotNull(entryMapper, "entryMapper");
             Ensure.NotNull(storyMapper, "storyMapper");
-            Ensure.NotNull(highestAltitudeService, "highestAltitudeService");
+            Ensure.NotNull(highestAltitudeMapper, "highestAltitudeMapper");
             Ensure.NotNull(connections, "connections");
             this.db = db;
             this.shareStatus = shareStatus;
             this.entryMapper = entryMapper;
             this.storyMapper = storyMapper;
-            this.highestAltitudeService = highestAltitudeService;
+            this.highestAltitudeMapper = highestAltitudeMapper;
             this.connections = connections;
         }
 
@@ -104,7 +104,12 @@ namespace Neptuo.Recollections.Entries.Controllers
             var userId = User.FindUserId();
             var connectedUsers = await connections.GetConnectedUsersForAsync(userId);
 
-            var models = await highestAltitudeService.GetListAsync(userId, connectedUsers, beingId);
+            string[] userIds = [userId, ShareStatusService.PublicUserId];
+            var accessibleEntries = shareStatus
+                .OwnedByOrExplicitlySharedWithUser(db, db.Entries.AsNoTracking(), userIds, connectedUsers)
+                .Where(e => e.Beings.Any(b => b.Id == beingId));
+
+            var models = await highestAltitudeMapper.MapAsync(accessibleEntries, userId, userIds, connectedUsers);
             return Ok(models);
         });
     }

--- a/src/Recollections.Api/Entries/Controllers/HighestAltitudeController.cs
+++ b/src/Recollections.Api/Entries/Controllers/HighestAltitudeController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Neptuo.Recollections.Accounts;
 using Neptuo.Recollections.Sharing;
 using System.Collections.Generic;
@@ -10,7 +11,7 @@ namespace Neptuo.Recollections.Entries.Controllers;
 
 [Authorize]
 [Route("api/highest-altitude")]
-public class HighestAltitudeController(DataContext dataContext, HighestAltitudeService service, ShareStatusService shareStatus, IConnectionProvider connections)
+public class HighestAltitudeController(DataContext dataContext, HighestAltitudeMapper mapper, ShareStatusService shareStatus, IConnectionProvider connections)
     : ControllerBase(dataContext, shareStatus)
 {
     [HttpGet]
@@ -24,7 +25,10 @@ public class HighestAltitudeController(DataContext dataContext, HighestAltitudeS
             return Unauthorized();
 
         var connectedUsers = await connections.GetConnectedUsersForAsync(userId);
-        var models = await service.GetListAsync(userId, connectedUsers);
+        var accessibleEntries = shareStatus.OwnedByOrExplicitlySharedWithUser(
+            dataContext, dataContext.Entries.AsNoTracking(), userId, connectedUsers);
+
+        var models = await mapper.MapAsync(accessibleEntries, userId, [userId], connectedUsers);
         return Ok(models);
     }
 }

--- a/src/Recollections.Api/Entries/EntriesStartup.cs
+++ b/src/Recollections.Api/Entries/EntriesStartup.cs
@@ -87,7 +87,7 @@ namespace Neptuo.Recollections.Entries
                 .AddTransient<ImageResizeService>()
                 .AddTransient<EntryMediaMapper>()
                 .AddTransient<EntryListMapper>()
-                .AddTransient<HighestAltitudeService>()
+                .AddTransient<HighestAltitudeMapper>()
                 .AddTransient<StoryListMapper>()
                 .AddTransient<MapService>()
                 .AddSingleton<CountryService>()

--- a/src/Recollections.Api/Entries/Services/HighestAltitudeMapper.cs
+++ b/src/Recollections.Api/Entries/Services/HighestAltitudeMapper.cs
@@ -8,36 +8,11 @@ using System.Threading.Tasks;
 
 namespace Neptuo.Recollections.Entries;
 
-public class HighestAltitudeService(DataContext dataContext, EntryListMapper entryMapper, ShareStatusService shareStatus)
+public class HighestAltitudeMapper(DataContext dataContext, EntryListMapper entryMapper, ShareStatusService shareStatus)
 {
     public const int ItemCount = 20;
 
-    public Task<List<EntryListModel>> GetListAsync(string userId, ConnectedUsersModel connectedUsers)
-    {
-        Ensure.NotNullOrEmpty(userId, "userId");
-        Ensure.NotNull(connectedUsers, "connectedUsers");
-
-        IQueryable<Entry> accessibleEntries = shareStatus
-            .OwnedByOrExplicitlySharedWithUser(dataContext, dataContext.Entries.AsNoTracking(), userId, connectedUsers);
-
-        return GetListCoreAsync(accessibleEntries, userId, [userId], connectedUsers);
-    }
-
-    public Task<List<EntryListModel>> GetListAsync(string userId, ConnectedUsersModel connectedUsers, string beingId)
-    {
-        Ensure.NotNullOrEmpty(userId, "userId");
-        Ensure.NotNull(connectedUsers, "connectedUsers");
-        Ensure.NotNullOrEmpty(beingId, "beingId");
-
-        string[] userIds = [userId, ShareStatusService.PublicUserId];
-        IQueryable<Entry> accessibleEntries = shareStatus
-            .OwnedByOrExplicitlySharedWithUser(dataContext, dataContext.Entries.AsNoTracking(), userIds, connectedUsers)
-            .Where(e => e.Beings.Any(b => b.Id == beingId));
-
-        return GetListCoreAsync(accessibleEntries, userId, userIds, connectedUsers);
-    }
-
-    private async Task<List<EntryListModel>> GetListCoreAsync(IQueryable<Entry> accessibleEntries, string userId, string[] userIds, ConnectedUsersModel connectedUsers)
+    public async Task<List<EntryListModel>> MapAsync(IQueryable<Entry> accessibleEntries, string userId, string[] userIds, ConnectedUsersModel connectedUsers)
     {
         List<EntryAltitudeInfo> rankedEntries = await GetRankedEntriesAsync(accessibleEntries);
         if (rankedEntries.Count == 0)


### PR DESCRIPTION
Follow-up to #483. `HighestAltitudeService` handled both access-control filtering and data mapping in a single class, unlike `StoryListMapper` and `EntryListMapper` where controllers build the filtered query and the mapper only handles loading, sorting, and mapping.

## Approach

Rename `HighestAltitudeService` to `HighestAltitudeMapper` and collapse the two `GetListAsync` overloads into a single `MapAsync` method that receives a pre-filtered `IQueryable<Entry>`. The preliminary filtering -- share status checks, being joins, `AsNoTracking` -- now lives in `HighestAltitudeController` and `BeingEntriesController`, matching how the other controllers use their mappers.

- **HighestAltitudeMapper** -- single `MapAsync(IQueryable<Entry>, userId, userIds, connectedUsers)` that ranks by altitude, loads via `EntryListMapper`, and enriches models with the altitude value
- **HighestAltitudeController** -- builds the accessible entries query, passes it to the mapper
- **BeingEntriesController** -- adds the being filter before passing to the mapper
- **EntriesStartup** -- DI registration updated

All 9 existing highest-altitude tests pass unchanged.