### PR TITLE
Show entry card popover on map marker click in detail pages

### DIFF
--- a/src/Recollections.Blazor.Components/wwwroot/Map.js
+++ b/src/Recollections.Blazor.Components/wwwroot/Map.js
@@ -212,10 +212,10 @@ function setMarkers(model, markers, isEditable) {
 
         const marker = Leaflet.marker(point, markerOptions).addTo(model.map);
         marker.id = i;
+        marker.on("click", e => {
+            model.interop.invokeMethodAsync("MapInterop.MarkerSelected", e.target.id);
+        });
         if (isEditable) {
-            marker.on("click", e => {
-                model.interop.invokeMethodAsync("MapInterop.MarkerSelected", e.target.id);
-            });
             marker.on("dragend", e => {
                 const latitude = e.target.getLatLng().lat;
                 const longitude = e.target.getLatLng().lng;

--- a/src/Recollections.Blazor.UI/Accounts/Pages/Profile.razor
+++ b/src/Recollections.Blazor.UI/Accounts/Pages/Profile.razor
@@ -29,7 +29,7 @@
 
                 <div class="gps">
                     <MapToggle DialogTitle="@($"{Owner.Name}: Map")" Text="@(Markers.Count == 0 ? "No locations..." : $"{Markers.Count} locations")" IsPlaceHolder="@(Markers.Count == 0)" IsEnabled="@(Markers.Count != 0)">
-                        <Map Markers="@Markers" MarkerSelected="OnMarkerSelected" />
+                        <Map @ref="mapComponent" Markers="@Markers" MarkerSelected="OnMarkerSelectedAsync" />
                     </MapToggle>
                 </div>
 
@@ -53,6 +53,8 @@
             </div>
         </PermissionContainer>
     </CascadingValue>
+
+    <EntryCardPopover @ref="entryPopover" Model="PopoverHandler.SelectedEntry" />
 
     <Offcanvas @ref="StoriesOffcanvas" class="offcanvas-half" Direction="start" Title="@($"Stories by {Owner.Name}")" IsBodyRenderedLazily="true">
         <div class="row">

--- a/src/Recollections.Blazor.UI/Accounts/Pages/Profile.razor.cs
+++ b/src/Recollections.Blazor.UI/Accounts/Pages/Profile.razor.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Neptuo.Recollections.Accounts.Pages
 {
-    public partial class Profile
+    public partial class Profile : IAsyncDisposable
     {
         [Inject]
         protected Api Api { get; set; }
@@ -35,6 +35,9 @@ namespace Neptuo.Recollections.Accounts.Pages
         protected OwnerModel Owner { get; set; }
         protected PermissionContainerState Permissions { get; } = new PermissionContainerState();
 
+        protected MapPopoverHandler PopoverHandler { get; } = new();
+        protected Map mapComponent;
+        protected EntryCardPopover entryPopover;
         protected List<MapEntryModel> MapEntries { get; set; } = new List<MapEntryModel>();
         protected List<MapMarkerModel> Markers { get; } = new List<MapMarkerModel>();
 
@@ -101,10 +104,22 @@ namespace Neptuo.Recollections.Accounts.Pages
             return markers;
         }
 
-        protected void OnMarkerSelected(int index)
+        protected async Task OnMarkerSelectedAsync(int index)
         {
-            var entry = MapEntries[index];
-            Navigator.OpenEntryDetail(entry.Entry.Id);
+            await PopoverHandler.SelectAsync(index, MapEntries[index].Entry, entryPopover);
+            StateHasChanged();
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+            await PopoverHandler.TryShowPopoverAsync(mapComponent, entryPopover);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (entryPopover != null)
+                await PopoverHandler.DisposeAsync(entryPopover);
         }
 
         protected string FormatAltitudeTitle(EntryListModel entry)

--- a/src/Recollections.Blazor.UI/Accounts/Pages/Profile.razor.cs
+++ b/src/Recollections.Blazor.UI/Accounts/Pages/Profile.razor.cs
@@ -118,8 +118,7 @@ namespace Neptuo.Recollections.Accounts.Pages
 
         public async ValueTask DisposeAsync()
         {
-            if (entryPopover != null)
-                await PopoverHandler.DisposeAsync(entryPopover);
+            await PopoverHandler.DisposeAsync(entryPopover);
         }
 
         protected string FormatAltitudeTitle(EntryListModel entry)

--- a/src/Recollections.Blazor.UI/Entries/Components/MapPopoverHandler.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/MapPopoverHandler.cs
@@ -1,0 +1,39 @@
+using Neptuo.Recollections.Components;
+using System.Threading.Tasks;
+
+namespace Neptuo.Recollections.Entries.Components
+{
+    public class MapPopoverHandler
+    {
+        private int selectedMarkerIndex = -1;
+        private bool showPopoverPending;
+
+        public EntryListModel SelectedEntry { get; private set; }
+
+        public async Task SelectAsync(int markerIndex, EntryListModel entry, EntryCardPopover popover)
+        {
+            await popover.HideAsync();
+            selectedMarkerIndex = markerIndex;
+            SelectedEntry = entry;
+            showPopoverPending = true;
+        }
+
+        public async Task TryShowPopoverAsync(Map map, EntryCardPopover popover)
+        {
+            if (showPopoverPending)
+            {
+                showPopoverPending = false;
+
+                if (SelectedEntry != null && selectedMarkerIndex >= 0 && map != null)
+                {
+                    await map.ShowMarkerPopoverAsync(selectedMarkerIndex, popover.ContentRef);
+                }
+            }
+        }
+
+        public async ValueTask DisposeAsync(EntryCardPopover popover)
+        {
+            await popover.HideAsync();
+        }
+    }
+}

--- a/src/Recollections.Blazor.UI/Entries/Components/MapPopoverHandler.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/MapPopoverHandler.cs
@@ -33,7 +33,8 @@ namespace Neptuo.Recollections.Entries.Components
 
         public async ValueTask DisposeAsync(EntryCardPopover popover)
         {
-            await popover.HideAsync();
+            if (popover != null)
+                await popover.HideAsync();
         }
     }
 }

--- a/src/Recollections.Blazor.UI/Entries/Pages/BeingDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/BeingDetail.razor
@@ -33,7 +33,7 @@
                 <UserInformation Owner="@Owner" />
                 <div class="gps">
                     <MapToggle DialogTitle="@($"{Model.Name}: Map")" Text="@(Markers.Count == 0 ? "No locations..." : $"{Markers.Count} locations")" IsPlaceHolder="@(Markers.Count == 0)">
-                        <Map Markers="@Markers" MarkerSelected="OnMarkerSelected" />
+                        <Map @ref="mapComponent" Markers="@Markers" MarkerSelected="OnMarkerSelectedAsync" />
                     </MapToggle>
                 </div>
 
@@ -61,6 +61,8 @@
             </div>
         </PermissionContainer>
     </CascadingValue>
+
+    <EntryCardPopover @ref="entryPopover" Model="PopoverHandler.SelectedEntry" />
 
     <BeingIconPicker @ref="IconPicker" Value="@Model.Icon" Selected="@(async value => await SaveIconAsync(value))" />
 

--- a/src/Recollections.Blazor.UI/Entries/Pages/BeingDetail.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Pages/BeingDetail.razor.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Neptuo.Recollections.Entries.Pages
 {
-    public partial class BeingDetail : UserStateComponentBase
+    public partial class BeingDetail : UserStateComponentBase, IAsyncDisposable
     {
         [Inject]
         protected Api Api { get; set; }
@@ -37,6 +37,9 @@ namespace Neptuo.Recollections.Entries.Pages
 
         protected BeingIconPicker IconPicker { get; set; }
 
+        protected MapPopoverHandler PopoverHandler { get; } = new();
+        protected Map mapComponent;
+        protected EntryCardPopover entryPopover;
         protected List<MapEntryModel> MapEntries { get; set; } = new List<MapEntryModel>();
         protected List<MapMarkerModel> Markers { get; } = new List<MapMarkerModel>();
 
@@ -97,10 +100,22 @@ namespace Neptuo.Recollections.Entries.Pages
             }
         }
 
-        protected void OnMarkerSelected(int index)
+        protected async Task OnMarkerSelectedAsync(int index)
         {
-            var entry = MapEntries[index];
-            Navigator.OpenEntryDetail(entry.Entry.Id);
+            await PopoverHandler.SelectAsync(index, MapEntries[index].Entry, entryPopover);
+            StateHasChanged();
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+            await PopoverHandler.TryShowPopoverAsync(mapComponent, entryPopover);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (entryPopover != null)
+                await PopoverHandler.DisposeAsync(entryPopover);
         }
 
         protected async Task SaveAsync()

--- a/src/Recollections.Blazor.UI/Entries/Pages/BeingDetail.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Pages/BeingDetail.razor.cs
@@ -114,8 +114,7 @@ namespace Neptuo.Recollections.Entries.Pages
 
         public async ValueTask DisposeAsync()
         {
-            if (entryPopover != null)
-                await PopoverHandler.DisposeAsync(entryPopover);
+            await PopoverHandler.DisposeAsync(entryPopover);
         }
 
         protected async Task SaveAsync()

--- a/src/Recollections.Blazor.UI/Entries/Pages/MapPage.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/MapPage.razor
@@ -15,4 +15,4 @@ else
     </div>
 }
 
-<EntryCardPopover @ref="entryPopover" Model="SelectedEntry" />
+<EntryCardPopover @ref="entryPopover" Model="PopoverHandler.SelectedEntry" />

--- a/src/Recollections.Blazor.UI/Entries/Pages/MapPage.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Pages/MapPage.razor.cs
@@ -28,11 +28,9 @@ namespace Neptuo.Recollections.Entries.Pages
 
         protected bool IsLoading { get; set; } = true;
 
-        protected EntryListModel SelectedEntry { get; set; }
+        protected MapPopoverHandler PopoverHandler { get; } = new();
         protected EntryCardPopover entryPopover;
         protected Map mapComponent;
-        private int selectedMarkerIndex = -1;
-        private bool showPopoverPending;
 
         protected async override Task OnInitializedAsync()
         {
@@ -61,31 +59,19 @@ namespace Neptuo.Recollections.Entries.Pages
 
         protected async Task OnMarkerSelectedAsync(int index)
         {
-            await entryPopover.HideAsync();
-            selectedMarkerIndex = index;
-            SelectedEntry = Entries[index].Entry;
-            showPopoverPending = true;
+            await PopoverHandler.SelectAsync(index, Entries[index].Entry, entryPopover);
             StateHasChanged();
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             await base.OnAfterRenderAsync(firstRender);
-
-            if (showPopoverPending)
-            {
-                showPopoverPending = false;
-
-                if (SelectedEntry != null && selectedMarkerIndex >= 0)
-                {
-                    await mapComponent.ShowMarkerPopoverAsync(selectedMarkerIndex, entryPopover.ContentRef);
-                }
-            }
+            await PopoverHandler.TryShowPopoverAsync(mapComponent, entryPopover);
         }
 
         public async ValueTask DisposeAsync()
         {
-            await entryPopover.HideAsync();
+            await PopoverHandler.DisposeAsync(entryPopover);
         }
     }
 }

--- a/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor
@@ -36,7 +36,7 @@
                 <UserInformation Owner="@Owner" />
                 <div class="gps">
                     <MapToggle DialogTitle="@($"{Model.Title}: Map")" Text="@(Markers.Count == 0 ? "No locations..." : $"{Markers.Count} locations")" IsPlaceHolder="@(Markers.Count == 0)" IsEnabled="@(Markers.Count != 0)">
-                        <Map Markers="@Markers" MarkerSelected="OnMarkerSelected" />
+                        <Map @ref="mapComponent" Markers="@Markers" MarkerSelected="OnMarkerSelectedAsync" />
                     </MapToggle>
                 </div>
                 @{
@@ -85,6 +85,8 @@
             </div>
         </PermissionContainer>
     </CascadingValue>
+
+    <EntryCardPopover @ref="entryPopover" Model="PopoverHandler.SelectedEntry" />
 
     <EntryPicker @ref="EntryPicker" Selected="EntrySelected" />
 </LoadingSection>

--- a/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace Neptuo.Recollections.Entries.Pages
 {
-    public partial class StoryDetail(ILog<StoryDetail> log)
+    public partial class StoryDetail(ILog<StoryDetail> log) : IAsyncDisposable
     {
         [Inject]
         protected Api Api { get; set; }
@@ -46,6 +46,9 @@ namespace Neptuo.Recollections.Entries.Pages
         protected InlineTextEdit LastChapterTitleEdit { get; set; }
         protected GalleryPreviewModal GalleryPreviewModal { get; set; }
         
+        protected MapPopoverHandler PopoverHandler { get; } = new();
+        protected Map mapComponent;
+        protected EntryCardPopover entryPopover;
         protected List<MapEntryModel> MapEntries { get; set; } = new List<MapEntryModel>();
         protected List<MapMarkerModel> Markers { get; } = new List<MapMarkerModel>();
 
@@ -64,6 +67,8 @@ namespace Neptuo.Recollections.Entries.Pages
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             await base.OnAfterRenderAsync(firstRender);
+
+            await PopoverHandler.TryShowPopoverAsync(mapComponent, entryPopover);
 
             if (SelectLastChapterTitleEdit)
             {
@@ -148,10 +153,16 @@ namespace Neptuo.Recollections.Entries.Pages
             }
         }
 
-        protected void OnMarkerSelected(int index)
+        protected async Task OnMarkerSelectedAsync(int index)
         {
-            var entry = MapEntries[index];
-            Navigator.OpenEntryDetail(entry.Entry.Id);
+            await PopoverHandler.SelectAsync(index, MapEntries[index].Entry, entryPopover);
+            StateHasChanged();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (entryPopover != null)
+                await PopoverHandler.DisposeAsync(entryPopover);
         }
 
         protected async Task SaveAsync()

--- a/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor.cs
@@ -161,8 +161,7 @@ namespace Neptuo.Recollections.Entries.Pages
 
         public async ValueTask DisposeAsync()
         {
-            if (entryPopover != null)
-                await PopoverHandler.DisposeAsync(entryPopover);
+            await PopoverHandler.DisposeAsync(entryPopover);
         }
 
         protected async Task SaveAsync()


### PR DESCRIPTION
After #487, the main map page shows an entry card popover when a marker is clicked. However, the maps on being, story, and profile detail pages did nothing on marker click. This PR adds the same popover behavior to those pages.

## Approach

**JS fix:** The marker click handler in `Map.js` was only bound when `isEditable` was true. Since detail page maps are read-only, clicks were silently ignored. The fix always binds the `MarkerSelected` click handler while keeping drag-only behavior gated on edit mode.

**Shared helper:** Extracted `MapPopoverHandler` to deduplicate the popover state management (select, show-after-render, dispose) that was previously inline in `MapPage`. All four pages now use this shared handler.

## Changed pages

- **BeingDetail** -- marker click shows entry card popover
- **StoryDetail** -- marker click shows entry card popover
- **Profile** -- marker click shows entry card popover
- **MapPage** -- refactored to use `MapPopoverHandler` (no behavior change)