### PR TITLE
Add release notes for v0.19.0

### DIFF
--- a/src/Recollections.Blazor.UI/wwwroot/release-notes.html
+++ b/src/Recollections.Blazor.UI/wwwroot/release-notes.html
@@ -1,12 +1,19 @@
 <h3>New features</h3>
 <ul>
-    <li>Timeline no longer jumps back to a previously opened entry</li>
-    <li>Related stories on Being detail are now shown only once</li>
+    <li>New Highest altitude view, with dedicated versions on beings and user profiles</li>
+    <li>Map, stories, and highest altitude views on user profiles</li>
+    <li>Swipe between months on the calendar view</li>
+    <li>Tap entries on calendar and map views to see a quick card preview</li>
+    <li>Push notifications when your connections share new entries</li>
+    <li>Global drag-and-drop upload form with media preview before upload</li>
+    <li>Upload progress visible on entry media, with a lighter progress visual in the PWA</li>
+    <li>Manage GPX tracks on entries and see total elevation</li>
+    <li>Loading progress bars for async operations across the app</li>
 </ul>
 
 <div class="row">
     <div class="col-12 col-md-auto">
-        <a target="_blank" rel="noopener noreferrer" href="https://github.com/neptuo/Recollections/milestone/49?closed=1" class="btn bg-light-subtle w-100">
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/neptuo/Recollections/milestone/50?closed=1" class="btn bg-light-subtle w-100">
             <span class="fab fa-github"></span>
             See details on GitHub
         </a>


### PR DESCRIPTION
Updates the in-app release notes page for the v0.19.0 milestone so users see the new features the next time they open the app.

Summarizes milestone #50 into user-facing bullets (highest altitude views, user profile views, calendar swipe and card previews, push notifications, global upload form, GPX tracks, loading progress) and points the "See details on GitHub" button at the v0.19.0 milestone. Internal refactors and CI-only items were excluded.