### PR TITLE
Fetch media directly in JS via bearer token

### DIFF
--- a/src/Recollections.Blazor.Components/Components/Gallery.razor.cs
+++ b/src/Recollections.Blazor.Components/Components/Gallery.razor.cs
@@ -20,7 +20,7 @@ namespace Neptuo.Recollections.Components
         public List<GalleryModel> Models { get; set; }
 
         [Parameter]
-        public Func<int, string, Task<Stream>> DataGetter { get; set; }
+        public string BearerToken { get; set; }
 
         [Parameter]
         public EventCallback<int> OnOpenInfo { get; set; }
@@ -37,13 +37,14 @@ namespace Neptuo.Recollections.Components
                     hashCode.Add(model);
             }
 
+            hashCode.Add(BearerToken);
             return hashCode.ToHashCode();
         }
 
         protected async override Task OnAfterRenderAsync(bool firstRender)
         {
             await base.OnAfterRenderAsync(firstRender);
-            await Interop.InitializedAsync(this, Models ?? []);
+            await Interop.InitializedAsync(this, Models ?? [], BearerToken);
 
             // 'Models' is passed as reference, so when SetParametersAsync is called, it already contains a new items.
             // Because of that it's important we compute the 'previous' value at the end of the rendering cycle,
@@ -71,7 +72,7 @@ namespace Neptuo.Recollections.Components
         {
             if (Models.Count > index)
             {
-                await Interop.InitializedAsync(this, Models ?? []);
+                await Interop.InitializedAsync(this, Models ?? [], BearerToken);
                 await Interop.OpenAsync(index);
             }
         }

--- a/src/Recollections.Blazor.Components/Components/GalleryInterop.cs
+++ b/src/Recollections.Blazor.Components/Components/GalleryInterop.cs
@@ -22,7 +22,7 @@ namespace Neptuo.Recollections.Components
             this.js = js;
         }
 
-        public async Task InitializedAsync(Gallery component, List<GalleryModel> models)
+        public async Task InitializedAsync(Gallery component, List<GalleryModel> models, string bearerToken)
         {
             Ensure.NotNull(component, "component");
             this.component = component;
@@ -30,7 +30,7 @@ namespace Neptuo.Recollections.Components
             module ??= await js.InvokeAsync<IJSObjectReference>("import", "./_content/Recollections.Blazor.Components/Gallery.js");
             selfReference ??= DotNetObjectReference.Create(this);
 
-            await module.InvokeVoidAsync("initialize", selfReference, models);
+            await module.InvokeVoidAsync("initialize", selfReference, models, bearerToken);
         }
 
         public async Task OpenAsync(int index)
@@ -51,19 +51,6 @@ namespace Neptuo.Recollections.Components
                 return false;
 
             return await module.InvokeAsync<bool>("isOpen");
-        }
-
-        [JSInvokable]
-        public async Task<DotNetStreamReference> GetImageDataAsync(int index, string type)
-        {
-            if (component?.DataGetter == null)
-                return null;
- 
-            var stream = await component.DataGetter(index, type);
-            if (stream == null)
-                return null;
-
-            return new DotNetStreamReference(stream);
         }
 
         [JSInvokable]

--- a/src/Recollections.Blazor.Components/Components/GalleryModel.cs
+++ b/src/Recollections.Blazor.Components/Components/GalleryModel.cs
@@ -21,8 +21,18 @@ namespace Neptuo.Recollections.Components
 
         public string ContentType { get; set; }
 
+        /// <summary>
+        /// Absolute URL of the preview-sized media (thumbnail for images, preview poster for videos).
+        /// </summary>
+        public string PreviewUrl { get; set; }
+
+        /// <summary>
+        /// Absolute URL of the original-sized media (used to stream original videos).
+        /// </summary>
+        public string OriginalUrl { get; set; }
+
         public override int GetHashCode()
-            => HashCode.Combine(Type, Title, SizeText, Width, Height, ContentType);
+            => HashCode.Combine(Type, Title, SizeText, Width, Height, ContentType, PreviewUrl, OriginalUrl);
 
         public override bool Equals(object obj)
             => (obj is GalleryModel other) && Equals(other);
@@ -33,6 +43,8 @@ namespace Neptuo.Recollections.Components
                 && SizeText == other.SizeText
                 && Width == other.Width
                 && Height == other.Height
-                && ContentType == other.ContentType;
+                && ContentType == other.ContentType
+                && PreviewUrl == other.PreviewUrl
+                && OriginalUrl == other.OriginalUrl;
     }
 }

--- a/src/Recollections.Blazor.Components/Components/ImageInterop.cs
+++ b/src/Recollections.Blazor.Components/Components/ImageInterop.cs
@@ -19,5 +19,8 @@ namespace Neptuo.Recollections.Components
 
         public ValueTask SetAsync(IJSObjectReference element, Stream stream, string contentType = null)
             => SetInternalAsync(element, stream, contentType);
+
+        public ValueTask<int> SetFromUrlAsync(ElementReference element, string url, string contentType = null, string bearerToken = null)
+            => jsRuntime.InvokeAsync<int>("ImageSource.SetFromUrl", element, url, contentType, bearerToken);
     }
 }

--- a/src/Recollections.Blazor.Components/wwwroot/Gallery.js
+++ b/src/Recollections.Blazor.Components/wwwroot/Gallery.js
@@ -11,6 +11,7 @@ let autoPlayTimer = null;
 let stopCallback = () => { };
 let interop = null;
 let items = [];
+let bearerToken = null;
 
 const playDurationSeconds = 4;
 const playIcon = '<i class="fas fa-play"></i>';
@@ -74,9 +75,34 @@ function formatTitle(model, title) {
     return `${title} (${hint})`;
 }
 
-export function initialize(intr, i) {
+async function fetchBlobUrl(url, mimeType) {
+    const headers = {};
+    if (bearerToken) {
+        headers["Authorization"] = "Bearer " + bearerToken;
+    }
+
+    let response;
+    try {
+        response = await fetch(url, { headers });
+    } catch (e) {
+        console.warn("Gallery.fetchBlobUrl: fetch failed", url, e);
+        return null;
+    }
+
+    if (!response.ok) {
+        return null;
+    }
+
+    const blob = await response.blob();
+    const blobType = mimeType || blob.type || undefined;
+    const typedBlob = blobType && blob.type !== blobType ? blob.slice(0, blob.size, blobType) : blob;
+    return URL.createObjectURL(typedBlob);
+}
+
+export function initialize(intr, i, token) {
     interop = intr;
     items = i;
+    bearerToken = token;
 
     if (!isInitiazed) {
         lightbox.on('uiRegister', function () {
@@ -189,17 +215,11 @@ export function initialize(intr, i) {
                 const originalTitle = lightbox.pswp.currSlide.data.alt || '';
 
                 titleEl.innerHTML = `${videoIcon} ${originalTitle} (loading video...)`;
-                
-                const stream = await invokeInterop("GetImageDataAsync", index, "original");
-                if (!stream) {
+
+                const url = await fetchBlobUrl(model.originalUrl, model.contentType || "video/mp4");
+                if (!url) {
                     return;
                 }
-
-                const arrayBuffer = await stream.arrayBuffer();
-                const blob = new Blob([arrayBuffer], {
-                    type: model.contentType || "video/mp4"
-                });
-                const url = URL.createObjectURL(blob);
 
                 const imageEl = lightbox.pswp.currSlide.image;
                 const videoEl = document.createElement('video');
@@ -243,17 +263,12 @@ export function initialize(intr, i) {
                 e.itemData.provider = model.provider;
             } else {
                 e.itemData.provider = model.provider = new Promise(async resolve => {
-                    const stream = await invokeInterop("GetImageDataAsync", e.index, "");
-                    if (!stream) {
+                    const url = await fetchBlobUrl(model.previewUrl, model.contentType || "image/jpeg");
+                    if (!url) {
                         resolve('');
                         return;
                     }
 
-                    const arrayBuffer = await stream.arrayBuffer();
-                    const blob = new Blob([arrayBuffer], {
-                        type: "image/png"
-                    });
-                    const url = URL.createObjectURL(blob);
                     model.src = url;
 
                     console.log(`Loading image at index '${e.index}'`);

--- a/src/Recollections.Blazor.Components/wwwroot/Gallery.js
+++ b/src/Recollections.Blazor.Components/wwwroot/Gallery.js
@@ -12,6 +12,7 @@ let stopCallback = () => { };
 let interop = null;
 let items = [];
 let bearerToken = null;
+const createdObjectUrls = new Set();
 
 const playDurationSeconds = 4;
 const playIcon = '<i class="fas fa-play"></i>';
@@ -76,30 +77,43 @@ function formatTitle(model, title) {
 }
 
 async function fetchBlobUrl(url, mimeType) {
-    const headers = {};
-    if (bearerToken) {
-        headers["Authorization"] = "Bearer " + bearerToken;
-    }
-
-    let response;
-    try {
-        response = await fetch(url, { headers });
-    } catch (e) {
-        console.warn("Gallery.fetchBlobUrl: fetch failed", url, e);
+    const fetcher = window.ImageSource && window.ImageSource.FetchObjectUrlAsync;
+    if (!fetcher) {
+        console.error("Gallery.fetchBlobUrl: window.ImageSource.FetchObjectUrlAsync is not available");
         return null;
     }
 
-    if (!response.ok) {
-        return null;
+    const { objectUrl } = await fetcher(url, mimeType, bearerToken);
+    if (objectUrl) {
+        createdObjectUrls.add(objectUrl);
     }
+    return objectUrl;
+}
 
-    const blob = await response.blob();
-    const blobType = mimeType || blob.type || undefined;
-    const typedBlob = blobType && blob.type !== blobType ? blob.slice(0, blob.size, blobType) : blob;
-    return URL.createObjectURL(typedBlob);
+function revokeObjectUrl(url) {
+    if (url && createdObjectUrls.delete(url)) {
+        URL.revokeObjectURL(url);
+    }
+}
+
+function revokeAllObjectUrls() {
+    for (const url of createdObjectUrls) {
+        URL.revokeObjectURL(url);
+    }
+    createdObjectUrls.clear();
+    for (const model of items) {
+        if (model) {
+            model.src = null;
+            model.provider = null;
+        }
+    }
 }
 
 export function initialize(intr, i, token) {
+    if (items !== i) {
+        revokeAllObjectUrls();
+    }
+
     interop = intr;
     items = i;
     bearerToken = token;
@@ -222,6 +236,7 @@ export function initialize(intr, i, token) {
                 }
 
                 const imageEl = lightbox.pswp.currSlide.image;
+                const previousSrc = imageEl.getAttribute('src');
                 const videoEl = document.createElement('video');
                 videoEl.src = url;
                 videoEl.controls = true;
@@ -234,6 +249,13 @@ export function initialize(intr, i, token) {
                 imageEl.parentNode.replaceChild(videoEl, imageEl);
                 lightbox.pswp.currSlide.image = videoEl;
                 titleEl.style.display = 'none';
+
+                // The poster image that was showing before is no longer attached; drop its blob URL.
+                if (previousSrc && previousSrc === model.src) {
+                    revokeObjectUrl(previousSrc);
+                    model.src = null;
+                    model.provider = null;
+                }
             });
         });
 
@@ -263,7 +285,9 @@ export function initialize(intr, i, token) {
                 e.itemData.provider = model.provider;
             } else {
                 e.itemData.provider = model.provider = new Promise(async resolve => {
-                    const url = await fetchBlobUrl(model.previewUrl, model.contentType || "image/jpeg");
+                    // For videos the preview is a JPEG poster, so let the response content-type win.
+                    const previewMimeType = isVideo(model) ? null : (model.contentType || null);
+                    const url = await fetchBlobUrl(model.previewUrl, previewMimeType);
                     if (!url) {
                         resolve('');
                         return;
@@ -307,5 +331,7 @@ export function dispose() {
     autoPlayTimer = null;
     stopCallback();
     stopCallback = () => { };
+    revokeAllObjectUrls();
     items = [];
+    bearerToken = null;
 }

--- a/src/Recollections.Blazor.UI/Entries/Api.cs
+++ b/src/Recollections.Blazor.UI/Entries/Api.cs
@@ -111,7 +111,10 @@ namespace Neptuo.Recollections.Entries
             => faultHandler.Wrap(http.GetFromJsonAsync<AuthorizedModel<ImageModel>>($"entries/{entryId}/images/{imageId}"));
 
         public Task<Stream> GetMediaDataAsync(string url)
-            => faultHandler.Wrap(http.GetStreamAsync((settings.BaseUrl + url).Replace("api/api", "api")));
+            => faultHandler.Wrap(http.GetStreamAsync(GetMediaUrl(url)));
+
+        public string GetMediaUrl(string url)
+            => (settings.BaseUrl + url).Replace("api/api", "api");
 
         public Task UpdateImageAsync(string entryId, ImageModel model)
             => faultHandler.Wrap(http.PutAsJsonAsync($"entries/{entryId}/images/{model.Id}", model));

--- a/src/Recollections.Blazor.UI/Entries/Components/EntryMedia.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/EntryMedia.razor
@@ -20,19 +20,39 @@
 {
     RenderFragment RenderImage() 
     {
-        if (IsLoaded)
+        if (HasUrl)
         {
+            string mediaClass = $"rounded {(Type == MediaType.Thumbnail ? "ratio ratio-4x3" : "")} {(!IsLoaded ? "d-none" : "")}";
+
             if (IsVideoContent)
-                return @<video @ref="@Element" class="rounded @(Type == MediaType.Thumbnail ? "ratio ratio-4x3" : "")" controls playsinline preload autoplay />;
+            {
+                return @<text>
+                    <video @ref="@Element" class="@mediaClass" controls playsinline preload autoplay />
+                    @if (!IsLoaded)
+                    {
+                        @RenderPlaceholder()
+                    }
+                </text>;
+            }
 
             Action onClick = null;
             if (ClickToPlay && Video != null)
                 onClick = DownloadVideo;
 
-            return @<img @ref="@Element" class="rounded @(Type == MediaType.Thumbnail ? "ratio ratio-4x3" : "")" @onclick="@onClick" />;
+            return @<text>
+                <img @ref="@Element" class="@mediaClass" @onclick="@onClick" />
+                @if (!IsLoaded)
+                {
+                    @RenderPlaceholder()
+                }
+            </text>;
         }
 
-        return @<div class="img rounded @(Type == MediaType.Thumbnail ? "ratio ratio-4x3" : "") @(IsLoadingNotFound ? "alert m-0 alert-danger" : "placeholder")">
+        return RenderPlaceholder();
+    }
+
+    RenderFragment RenderPlaceholder() =>
+        @<div class="img rounded @(Type == MediaType.Thumbnail ? "ratio ratio-4x3" : "") @(IsLoadingNotFound ? "alert m-0 alert-danger" : "placeholder")">
             @if (IsLoadingNotFound)
             {
                 <div class="d-flex justify-content-center align-items-center">
@@ -50,6 +70,5 @@
                 </div>
             }
         </div>;
-    }
 }
 

--- a/src/Recollections.Blazor.UI/Entries/Components/EntryMedia.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/EntryMedia.razor
@@ -1,4 +1,4 @@
-﻿<div class="image justify-content-center @(!IsLoadingNotFound && Content == null ? "placeholder-glow" : "")">
+﻿<div class="image justify-content-center @(!IsLoadingNotFound && !IsLoaded ? "placeholder-glow" : "")">
     @if (OnClick.HasDelegate)
     {
         <a href="@GetLinkUrl()" class="position-relative d-block w-100" @onclick="@OnClick" @onclick:stopPropagation @onclick:preventDefault>
@@ -20,7 +20,7 @@
 {
     RenderFragment RenderImage() 
     {
-        if (Content != null)
+        if (IsLoaded)
         {
             if (IsVideoContent)
                 return @<video @ref="@Element" class="rounded @(Type == MediaType.Thumbnail ? "ratio ratio-4x3" : "")" controls playsinline preload autoplay />;

--- a/src/Recollections.Blazor.UI/Entries/Components/EntryMedia.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/EntryMedia.razor.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Neptuo.Logging;
+using Neptuo.Recollections.Accounts.Components;
 using Neptuo.Recollections.Components;
 using Neptuo.Recollections.Entries.Models;
 using System;
@@ -17,7 +18,7 @@ namespace Neptuo.Recollections.Entries.Components
         private string url;
         private string previousUrl;
 
-        protected Stream Content { get; private set; }
+        protected bool IsLoaded { get; private set; }
         protected bool IsLoadingNotFound { get; set; }
 
         [Inject]
@@ -32,8 +33,8 @@ namespace Neptuo.Recollections.Entries.Components
         [Inject]
         protected ILog<EntryMedia> Log { get; set; }
 
-        [Inject]
-        protected ExceptionPanelSuppression ExceptionPanelSuppression { get; set; }
+        [CascadingParameter]
+        protected UserState UserState { get; set; }
 
         [Parameter]
         [CascadingParameter]
@@ -61,7 +62,7 @@ namespace Neptuo.Recollections.Entries.Components
         public bool ClickToPlay { get; set; }
 
         protected ElementReference Element { get; set; }
-        
+
         protected bool IsVideoLoading = false;
         protected bool IsVideoContent = false;
 
@@ -83,63 +84,73 @@ namespace Neptuo.Recollections.Entries.Components
             previousUrl = url;
         }
 
-        protected async override Task OnParametersSetAsync()
+        protected override void OnParametersSet()
         {
-            await base.OnParametersSetAsync();
+            base.OnParametersSet();
 
-            if (!IsVideoContent)
+            if (IsVideoContent)
+                return;
+
+            string mediaUrl = null;
+            if (Image != null)
+                mediaUrl = FindImageUrl(Image);
+            else if (Video != null)
+                mediaUrl = FindImageUrl(Video);
+
+            if (mediaUrl != null)
             {
-                string mediaUrl = null;
-                if (Image != null)
-                    mediaUrl = FindImageUrl(Image);
-                else if (Video != null)
-                    mediaUrl = FindImageUrl(Video);
-
-                if (mediaUrl != null)
+                if (previousUrl != mediaUrl)
                 {
-                    if (previousUrl != mediaUrl)
-                    {
-                        IsLoadingNotFound = false;
-                        previousUrl = mediaUrl;
-                        url = mediaUrl;
-                        hasSourceChanged = true;
-                        _ = LoadMediaDataAsync(mediaUrl).ContinueWith(_ => StateHasChanged());
-                    }
-
-                    return;
-                }
-                else
-                {
-                    Content = null;
+                    IsLoadingNotFound = false;
+                    previousUrl = mediaUrl;
+                    url = mediaUrl;
+                    hasSourceChanged = true;
+                    IsLoaded = true;
                 }
             }
-        }
-
-        private async Task LoadMediaDataAsync(string mediaUrl)
-        {
-            using (ExceptionPanelSuppression.Enter<HttpRequestException>(e => e.StatusCode == HttpStatusCode.NotFound))
+            else
             {
-                try
-                {
-                    Log.Debug("Downloading media from {0}", mediaUrl);
-                    Content = await Api.GetMediaDataAsync(mediaUrl);
-                    Log.Debug("Media downloaded successfully");
-                }
-                catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.NotFound)
-                {
-                    Log.Debug("Exception during image download");
-                    IsLoadingNotFound = true;
-                }
+                url = null;
+                IsLoaded = false;
             }
         }
 
         protected async override Task OnAfterRenderAsync(bool firstRender)
         {
             await base.OnAfterRenderAsync(firstRender);
-            if (Content != null && hasSourceChanged)
+            if (hasSourceChanged && url != null)
             {
                 hasSourceChanged = false;
-                await ImageInterop.SetAsync(Element, Content, IsVideoContent ? Video?.ContentType : null);
+                await LoadFromUrlAsync(url, IsVideoContent ? Video?.ContentType : null);
+            }
+        }
+
+        private async Task LoadFromUrlAsync(string mediaUrl, string contentType)
+        {
+            string absoluteUrl = Api.GetMediaUrl(mediaUrl);
+            Log.Debug("Downloading media from {0}", absoluteUrl);
+
+            int status;
+            try
+            {
+                status = await ImageInterop.SetFromUrlAsync(Element, absoluteUrl, contentType, UserState?.BearerToken);
+            }
+            catch (Exception e)
+            {
+                Log.Debug("Exception during media download: {0}", e.Message);
+                return;
+            }
+
+            if (status == (int)HttpStatusCode.NotFound)
+            {
+                Log.Debug("Media not found");
+                IsLoadingNotFound = true;
+                IsLoaded = false;
+                StateHasChanged();
+            }
+            else
+            {
+                Log.Debug("Media downloaded successfully");
             }
         }
 
@@ -164,13 +175,13 @@ namespace Neptuo.Recollections.Entries.Components
                 return;
 
             IsVideoLoading = true;
-            LoadMediaDataAsync(FindImageUrl(Video, MediaType.Original)).ContinueWith(_ =>
-            {
-                IsVideoLoading = false;
-                IsVideoContent = true;
-                hasSourceChanged = true;
-                StateHasChanged();
-            });
+            IsVideoContent = true;
+            url = FindImageUrl(Video, MediaType.Original);
+            previousUrl = url;
+            hasSourceChanged = true;
+            IsLoaded = true;
+            IsVideoLoading = false;
+            StateHasChanged();
         }
     }
 }

--- a/src/Recollections.Blazor.UI/Entries/Components/EntryMedia.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/EntryMedia.razor.cs
@@ -1,13 +1,10 @@
 ﻿using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.Logging;
 using Neptuo.Logging;
 using Neptuo.Recollections.Accounts.Components;
 using Neptuo.Recollections.Components;
 using Neptuo.Recollections.Entries.Models;
 using System;
-using System.IO;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Neptuo.Recollections.Entries.Components
@@ -18,6 +15,7 @@ namespace Neptuo.Recollections.Entries.Components
         private string url;
         private string previousUrl;
 
+        protected bool HasUrl { get; private set; }
         protected bool IsLoaded { get; private set; }
         protected bool IsLoadingNotFound { get; set; }
 
@@ -102,15 +100,17 @@ namespace Neptuo.Recollections.Entries.Components
                 if (previousUrl != mediaUrl)
                 {
                     IsLoadingNotFound = false;
+                    IsLoaded = false;
                     previousUrl = mediaUrl;
                     url = mediaUrl;
                     hasSourceChanged = true;
-                    IsLoaded = true;
+                    HasUrl = true;
                 }
             }
             else
             {
                 url = null;
+                HasUrl = false;
                 IsLoaded = false;
             }
         }
@@ -137,21 +137,36 @@ namespace Neptuo.Recollections.Entries.Components
             }
             catch (Exception e)
             {
-                Log.Debug("Exception during media download: {0}", e.Message);
+                HandleMediaLoadFailure(0, $"Exception during media download: {e.Message}");
+                return;
+            }
+            finally
+            {
+                IsVideoLoading = false;
+            }
+
+            if (!IsSuccessfulStatus(status))
+            {
+                HandleMediaLoadFailure(status, $"Media download failed with status '{status}'");
                 return;
             }
 
-            if (status == (int)HttpStatusCode.NotFound)
-            {
-                Log.Debug("Media not found");
-                IsLoadingNotFound = true;
-                IsLoaded = false;
-                StateHasChanged();
-            }
-            else
-            {
-                Log.Debug("Media downloaded successfully");
-            }
+            Log.Debug("Media downloaded successfully");
+            IsLoaded = true;
+            IsLoadingNotFound = false;
+            StateHasChanged();
+        }
+
+        private static bool IsSuccessfulStatus(int status)
+            => status >= (int)HttpStatusCode.OK && status < 300;
+
+        private void HandleMediaLoadFailure(int status, string message)
+        {
+            Log.Debug(message);
+            IsLoadingNotFound = status == (int)HttpStatusCode.NotFound;
+            IsLoaded = false;
+            HasUrl = false;
+            StateHasChanged();
         }
 
         private string FindImageUrl(IMediaUrlList media, MediaType? type = null)
@@ -179,8 +194,8 @@ namespace Neptuo.Recollections.Entries.Components
             url = FindImageUrl(Video, MediaType.Original);
             previousUrl = url;
             hasSourceChanged = true;
-            IsLoaded = true;
-            IsVideoLoading = false;
+            HasUrl = true;
+            IsLoaded = false;
             StateHasChanged();
         }
     }

--- a/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor
@@ -14,7 +14,7 @@
             </div>
         }
 
-        <Gallery @ref="Gallery" Models="@GalleryItems" DataGetter="OnGetMediaDataAsync" OnOpenInfo="OnGalleryOpenInfoAsync" />
+        <Gallery @ref="Gallery" Models="@GalleryItems" BearerToken="@UserState.BearerToken" OnOpenInfo="OnGalleryOpenInfoAsync" />
         @BeforeContent
 
         @if(Collapsible && Entries.Count > 5)

--- a/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor.cs
@@ -246,7 +246,8 @@ namespace Neptuo.Recollections.Entries.Components
                         Type = "image",
                         Title = item.Image.Name,
                         Width = item.Image.Preview.Width,
-                        Height = item.Image.Preview.Height
+                        Height = item.Image.Preview.Height,
+                        PreviewUrl = Api.GetMediaUrl(item.Image.Preview.Url),
                     });
                 }
                 else if (item.Video != null)
@@ -257,25 +258,12 @@ namespace Neptuo.Recollections.Entries.Components
                         Title = item.Video.Name,
                         Width = item.Video.Preview.Width,
                         Height = item.Video.Preview.Height,
-                        ContentType = item.Video.ContentType
+                        ContentType = item.Video.ContentType,
+                        PreviewUrl = Api.GetMediaUrl(item.Video.Preview.Url),
+                        OriginalUrl = Api.GetMediaUrl(item.Video.Original.Url),
                     });
                 }
             }
-        }
-
-        protected Task<Stream> OnGetMediaDataAsync(int index, string type)
-        {
-            if (currentGalleryEntryId == null || !galleryMediaByEntryId.TryGetValue(currentGalleryEntryId, out List<MediaModel> media) || index >= media.Count)
-                return Task.FromResult<Stream>(null);
-
-            MediaModel item = media[index];
-            if (item.Image != null)
-                return Api.GetMediaDataAsync(item.Image.Preview.Url);
-
-            if (item.Video != null)
-                return Api.GetMediaDataAsync(type == "original" ? item.Video.Original.Url : item.Video.Preview.Url);
-
-            return Task.FromResult<Stream>(null);
         }
 
         protected async Task OnGalleryOpenInfoAsync(int index)

--- a/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor
@@ -92,7 +92,7 @@
                 @if (Media?.Count > 0)
                 {
                     <div class="images my-3">
-                        <Gallery @ref="Gallery" Models="@GalleryItems" DataGetter="OnGetMediaDataAsync" OnOpenInfo="@OnGalleryOpenInfoAsync" />
+                        <Gallery @ref="Gallery" Models="@GalleryItems" BearerToken="@UserState.BearerToken" OnOpenInfo="@OnGalleryOpenInfoAsync" />
 
                         @foreach (var item in Media)
                         {

--- a/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor.cs
@@ -228,7 +228,8 @@ namespace Neptuo.Recollections.Entries.Pages
                         Type = "image",
                         Title = item.Image.Name,
                         Width = item.Image.Preview.Width,
-                        Height = item.Image.Preview.Height
+                        Height = item.Image.Preview.Height,
+                        PreviewUrl = Api.GetMediaUrl(item.Image.Preview.Url),
                     });
                 }
                 else if (item.Video != null)
@@ -241,38 +242,13 @@ namespace Neptuo.Recollections.Entries.Pages
                         Width = item.Video.Preview.Width,
                         Height = item.Video.Preview.Height,
                         ContentType = item.Video.ContentType,
+                        PreviewUrl = Api.GetMediaUrl(item.Video.Preview.Url),
+                        OriginalUrl = Api.GetMediaUrl(item.Video.Original.Url),
                     });
                 }
             }
         }
 
-        protected async Task<Stream> OnGetMediaDataAsync(int index, string type)
-        {
-            if (index >= Media.Count)
-                return null;
-
-            var item = Media[index];
-            if (item.Image != null)
-            {
-                var image = item.Image;
-                Log.Debug($"Get image for gallery at '{index}' (count '{Media.Count}'), URL is '{image.Preview.Url}'.");
-
-                var stream = await Api.GetMediaDataAsync(image.Preview.Url);
-                Log.Debug($"Got image data for gallery at '{index}'");
-
-                return stream;
-            }
-            else if (item.Video != null)
-            {
-                if (type == "original")
-                    return await Api.GetMediaDataAsync(item.Video.Original.Url);
-                else
-                    return await Api.GetMediaDataAsync(item.Video.Preview.Url);
-            }
-
-            return null;
-        }
-        
         private async Task OnGalleryOpenInfoAsync(int index)
         {
             await Gallery.CloseAsync();

--- a/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor
@@ -80,7 +80,7 @@
                     }
                 </div>
 
-                <Gallery @ref="Gallery" Models="@GalleryItems" DataGetter="OnGetMediaDataAsync" OnOpenInfo="OnGalleryOpenInfoAsync" />
+                <Gallery @ref="Gallery" Models="@GalleryItems" BearerToken="@UserState.BearerToken" OnOpenInfo="OnGalleryOpenInfoAsync" />
                 <GalleryPreviewModal @ref="GalleryPreviewModal" Title="@Model.Title" Media="@AllMedia" OnMediaClick="@(index => Gallery.OpenAsync(index))" />
             </div>
         </PermissionContainer>

--- a/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor.cs
@@ -118,7 +118,8 @@ namespace Neptuo.Recollections.Entries.Pages
                             Type = "image",
                             Title = item.Image.Name,
                             Width = item.Image.Preview.Width,
-                            Height = item.Image.Preview.Height
+                            Height = item.Image.Preview.Height,
+                            PreviewUrl = Api.GetMediaUrl(item.Image.Preview.Url),
                         });
                     }
                     else if (item.Video != null)
@@ -131,6 +132,8 @@ namespace Neptuo.Recollections.Entries.Pages
                             Width = item.Video.Preview.Width,
                             Height = item.Video.Preview.Height,
                             ContentType = item.Video.ContentType,
+                            PreviewUrl = Api.GetMediaUrl(item.Video.Preview.Url),
+                            OriginalUrl = Api.GetMediaUrl(item.Video.Original.Url),
                         });
                     }
                 }
@@ -242,26 +245,6 @@ namespace Neptuo.Recollections.Entries.Pages
             entryId = null;
             media = null;
             return false;
-        }
-
-        protected Task<Stream> OnGetMediaDataAsync(int index, string type)
-        {
-            if (TryFindMedia(index, out _, out var item))
-            {
-                if (item.Image != null)
-                {
-                    return Api.GetMediaDataAsync(item.Image.Preview.Url);
-                }
-                else if (item.Video != null)
-                {
-                    if (type == "original")
-                        return Api.GetMediaDataAsync(item.Video.Original.Url);
-                    else
-                        return Api.GetMediaDataAsync(item.Video.Preview.Url);
-                }
-            }
-
-            return Task.FromResult<Stream>(null);
         }
 
         protected async Task OnGalleryOpenInfoAsync(int index)

--- a/src/Recollections.Blazor.UI/wwwroot/js/site.js
+++ b/src/Recollections.Blazor.UI/wwwroot/js/site.js
@@ -442,7 +442,7 @@ window.ImageSource = {
         }
         element.src = url;
     },
-    SetFromUrl: async function (element, url, mimeType, bearerToken) {
+    FetchObjectUrlAsync: async function (url, mimeType, bearerToken) {
         const headers = {};
         if (bearerToken) {
             headers["Authorization"] = "Bearer " + bearerToken;
@@ -452,31 +452,48 @@ window.ImageSource = {
         try {
             response = await fetch(url, { headers });
         } catch (e) {
-            console.warn("ImageSource.SetFromUrl: fetch failed", url, e);
-            return 0;
+            console.warn("ImageSource.FetchObjectUrlAsync: fetch failed", url, e);
+            return { status: 0, objectUrl: null };
         }
 
         if (!response.ok) {
-            return response.status;
+            return { status: response.status, objectUrl: null };
         }
 
         const blob = await response.blob();
         const blobType = mimeType || blob.type || undefined;
         const typedBlob = blobType && blob.type !== blobType ? blob.slice(0, blob.size, blobType) : blob;
-        const objectUrl = URL.createObjectURL(typedBlob);
-
-        const revoke = () => URL.revokeObjectURL(objectUrl);
-        const tag = element.tagName ? element.tagName.toLowerCase() : "";
-        if (tag === "video") {
-            element.addEventListener("loadeddata", revoke, { once: true });
-            element.addEventListener("error", revoke, { once: true });
-        } else {
-            element.addEventListener("load", revoke, { once: true });
-            element.addEventListener("error", revoke, { once: true });
+        return { status: response.status, objectUrl: URL.createObjectURL(typedBlob) };
+    },
+    SetFromUrl: async function (element, url, mimeType, bearerToken) {
+        const { status, objectUrl } = await window.ImageSource.FetchObjectUrlAsync(url, mimeType, bearerToken);
+        if (!objectUrl) {
+            return status;
         }
 
-        element.src = objectUrl;
-        return response.status;
+        return await new Promise(resolve => {
+            const tag = element.tagName ? element.tagName.toLowerCase() : "";
+            const loadEvent = tag === "video" ? "loadeddata" : "load";
+
+            const cleanup = () => {
+                element.removeEventListener(loadEvent, onLoad);
+                element.removeEventListener("error", onError);
+            };
+            const onLoad = () => {
+                cleanup();
+                URL.revokeObjectURL(objectUrl);
+                resolve(status);
+            };
+            const onError = () => {
+                cleanup();
+                URL.revokeObjectURL(objectUrl);
+                resolve(0);
+            };
+
+            element.addEventListener(loadEvent, onLoad, { once: true });
+            element.addEventListener("error", onError, { once: true });
+            element.src = objectUrl;
+        });
     }
 }
 

--- a/src/Recollections.Blazor.UI/wwwroot/js/site.js
+++ b/src/Recollections.Blazor.UI/wwwroot/js/site.js
@@ -441,6 +441,42 @@ window.ImageSource = {
             URL.revokeObjectURL(url);
         }
         element.src = url;
+    },
+    SetFromUrl: async function (element, url, mimeType, bearerToken) {
+        const headers = {};
+        if (bearerToken) {
+            headers["Authorization"] = "Bearer " + bearerToken;
+        }
+
+        let response;
+        try {
+            response = await fetch(url, { headers });
+        } catch (e) {
+            console.warn("ImageSource.SetFromUrl: fetch failed", url, e);
+            return 0;
+        }
+
+        if (!response.ok) {
+            return response.status;
+        }
+
+        const blob = await response.blob();
+        const blobType = mimeType || blob.type || undefined;
+        const typedBlob = blobType && blob.type !== blobType ? blob.slice(0, blob.size, blobType) : blob;
+        const objectUrl = URL.createObjectURL(typedBlob);
+
+        const revoke = () => URL.revokeObjectURL(objectUrl);
+        const tag = element.tagName ? element.tagName.toLowerCase() : "";
+        if (tag === "video") {
+            element.addEventListener("loadeddata", revoke, { once: true });
+            element.addEventListener("error", revoke, { once: true });
+        } else {
+            element.addEventListener("load", revoke, { once: true });
+            element.addEventListener("error", revoke, { once: true });
+        }
+
+        element.src = objectUrl;
+        return response.status;
     }
 }
 


### PR DESCRIPTION
Loading a video in `EntryMedia` currently takes several seconds even once the file is in the browser's cache. The bytes travel through the WASM `HttpClient` and are then copied chunk-by-chunk into JS via `DotNetStreamReference.arrayBuffer()` before being turned into a blob URL. That interop round-trip is the bulk of the wait time flagged in #421.

This PR moves the download into JS. Blazor now just passes the absolute URL, content type, and the current `UserState.BearerToken` to a shared `ImageSource.FetchObjectUrlAsync` / `ImageSource.SetFromUrl` helper, which performs a plain `fetch` with the `Authorization` header, wraps the response in a `Blob`, and assigns the resulting object URL to the `<img>` / `<video>` element. The response status is returned back to .NET so the existing 404 "Not found" placeholder still works.

### Scope
- `EntryMedia` (image / video on entry and detail pages)
- PhotoSwipe `Gallery` (preview fetch and click-to-play video): `Gallery.js` no longer uses `DotNetStreamReference` and instead calls the same `ImageSource.FetchObjectUrlAsync` helper with the bearer token.

### Notes for reviewers
- `Api.GetMediaUrl(url)` was extracted so C# and JS resolve the exact same absolute URL (including the `api/api` -> `api` fixup).
- `ExceptionPanelSuppression` is no longer injected in `EntryMedia` - non-2xx responses now flow through the returned status code instead of a thrown `HttpRequestException`. 404 drives the "Not found" placeholder; other non-2xx statuses fall back to the empty placeholder.
- `EntryMedia` splits `HasUrl` (we know the URL, render the element so `@ref` is populated) from `IsLoaded` (blob assigned, hide placeholder-glow) to avoid a flash of an empty element while the fetch is still in flight.
- Object URLs created by the gallery are tracked and revoked on `dispose` and when the poster `<img>` is replaced by the real `<video>`, so the blobs are not leaked.
- This is Variant 1 from the design discussion: it still buffers the full response into a blob before playback starts, but removes all WASM HTTP + interop overhead. A follow-up could swap in a service worker so `<video>.src` can point at the API directly and let the browser do range-based streaming natively.

Closes (partially) #421.
