### PR TITLE
Support ImageSharp.AVCodecFormats on macOS for development

### DIFF
--- a/src/Recollections.Entries/FFmpegMacOSInitializer.cs
+++ b/src/Recollections.Entries/FFmpegMacOSInitializer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using FFMediaToolkit;
 using HeyRed.ImageSharp.AVCodecFormats;
 
@@ -18,14 +19,23 @@ namespace Neptuo.Recollections.Entries
             "/usr/local/opt/ffmpeg@7/lib",
         };
 
-        private static bool initialized;
+        // FFmpeg 7.x dylibs we actually need. Versions match FFmpeg.AutoGen 7.1.1
+        // and FFMediaToolkit's dlopen set.
+        private static readonly string[] RequiredDylibs =
+        {
+            "libavcodec.61.dylib",
+            "libavformat.61.dylib",
+            "libavutil.59.dylib",
+            "libswscale.8.dylib",
+            "libswresample.5.dylib",
+        };
+
+        private static int initialized;
 
         public static void Initialize()
         {
-            if (initialized)
+            if (Interlocked.Exchange(ref initialized, 1) == 1)
                 return;
-
-            initialized = true;
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 return;
@@ -60,6 +70,17 @@ namespace Neptuo.Recollections.Entries
         }
 
         private static bool ContainsFFmpegDylibs(string directory)
-            => Directory.Exists(directory) && File.Exists(Path.Combine(directory, "libavcodec.61.dylib"));
+        {
+            if (!Directory.Exists(directory))
+                return false;
+
+            foreach (var dylib in RequiredDylibs)
+            {
+                if (!File.Exists(Path.Combine(directory, dylib)))
+                    return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/Recollections.Entries/FFmpegMacOSInitializer.cs
+++ b/src/Recollections.Entries/FFmpegMacOSInitializer.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using FFMediaToolkit;
+using HeyRed.ImageSharp.AVCodecFormats;
+
+namespace Neptuo.Recollections.Entries
+{
+    // Development-only helper: ImageSharp.AVCodecFormats.Native ships no macOS
+    // payload, so on macOS we point FFmpeg at a locally installed FFmpeg 7
+    // (e.g. Homebrew `ffmpeg@7`). FFmpeg.AutoGen 7.1.1 is pinned to the
+    // FFmpeg 7.x ABI, so ffmpeg 8 will not load.
+    internal static class FFmpegMacOSInitializer
+    {
+        private static readonly string[] CandidatePaths =
+        {
+            "/opt/homebrew/opt/ffmpeg@7/lib",
+            "/usr/local/opt/ffmpeg@7/lib",
+        };
+
+        private static bool initialized;
+
+        public static void Initialize()
+        {
+            if (initialized)
+                return;
+
+            initialized = true;
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return;
+
+            if (!string.IsNullOrWhiteSpace(FFmpegBinaries.Path))
+                return;
+
+            var envPath = Environment.GetEnvironmentVariable("RECOLLECTIONS_FFMPEG_PATH");
+            if (!string.IsNullOrWhiteSpace(envPath) && ContainsFFmpegDylibs(envPath))
+            {
+                Apply(envPath);
+                return;
+            }
+
+            foreach (var candidate in CandidatePaths)
+            {
+                if (ContainsFFmpegDylibs(candidate))
+                {
+                    Apply(candidate);
+                    return;
+                }
+            }
+        }
+
+        private static void Apply(string path)
+        {
+            // Set both: FFmpegLoader is what FFMediaToolkit actually uses to
+            // locate the dylibs, FFmpegBinaries.Path short-circuits the
+            // library's auto-finder so it doesn't overwrite us.
+            FFmpegLoader.FFmpegPath = path;
+            FFmpegBinaries.Path = path;
+        }
+
+        private static bool ContainsFFmpegDylibs(string directory)
+            => Directory.Exists(directory) && File.Exists(Path.Combine(directory, "libavcodec.61.dylib"));
+    }
+}

--- a/src/Recollections.Entries/VideoService.cs
+++ b/src/Recollections.Entries/VideoService.cs
@@ -23,6 +23,11 @@ namespace Neptuo.Recollections.Entries
         private const int ThumbnailWidth = 200;
         private const int ThumbnailHeight = 150;
 
+        static VideoService()
+        {
+            FFmpegMacOSInitializer.Initialize();
+        }
+
         private readonly DataContext dataContext;
         private readonly IFileStorage fileStorage;
         private readonly ImageResizeService resizeService;


### PR DESCRIPTION
## Why

`ImageSharp.AVCodecFormats` works fine on macOS as managed code (its `FFmpegBinariesFinder` and the bundled FFMediaToolkit both have `OSPlatform.OSX` branches), but the `ImageSharp.AVCodecFormats.Native` meta-package only depends on `…Native.win-x64` and `…Native.linux-x64`. There is no osx-arm64 payload, so video decoding throws on Apple Silicon dev machines.

## Approach

Add a small `FFmpegMacOSInitializer` that, on macOS only, locates a locally installed FFmpeg 7 and points the library at it:

- Probes `RECOLLECTIONS_FFMPEG_PATH`, then `/opt/homebrew/opt/ffmpeg@7/lib`, then `/usr/local/opt/ffmpeg@7/lib` for `libavcodec.61.dylib`.
- Sets `FFMediaToolkit.FFmpegLoader.FFmpegPath` (what FFMediaToolkit actually `dlopen`s against) **and** `HeyRed.ImageSharp.AVCodecFormats.FFmpegBinaries.Path` (to short-circuit the library's auto-finder so it does not overwrite our path).
- No-op on Windows and Linux, where the native NuGet payload works normally.

Wired from `VideoService`'s static constructor so it runs once, lazily, before any decode.

## Dev setup

```
brew install ffmpeg@7
```

`ffmpeg@7` is keg-only, so it does not conflict with a regular `ffmpeg` install. FFmpeg.AutoGen 7.1.1 is pinned to the FFmpeg 7.x ABI, so Homebrew's current `ffmpeg` (8.x) will not load.

## Notes for review

- This is intentionally a dev convenience, not a production packaging fix. Publishing/deployment targets continue to rely on the Windows/Linux native NuGets.
- Setting only `FFmpegBinaries.Path` looks sufficient but is not - that field is a side effect of the library's own finder, and FFMediaToolkit reads a different property. Verified with a standalone smoke test against `avc.mp4` before and after the fix.