### PR TITLE
Fix EF Core migrations for Azure SQL compatibility

### DIFF
--- a/src/Recollections.Accounts.Data/DataContext.cs
+++ b/src/Recollections.Accounts.Data/DataContext.cs
@@ -77,10 +77,12 @@ namespace Neptuo.Recollections.Accounts
 
             modelBuilder.Entity<UserNotificationNewEntriesDispatch>()
                 .Property(p => p.UserId)
+                .HasMaxLength(36)
                 .IsRequired();
 
             modelBuilder.Entity<UserNotificationNewEntriesDispatch>()
                 .Property(p => p.EntryId)
+                .HasMaxLength(36)
                 .IsRequired();
 
             modelBuilder.Entity<UserNotificationNewEntriesDispatch>()

--- a/src/Recollections.Accounts.Data/DataContext.cs
+++ b/src/Recollections.Accounts.Data/DataContext.cs
@@ -102,6 +102,7 @@ namespace Neptuo.Recollections.Accounts
 
             modelBuilder.Entity<UserNotificationPushSubscription>()
                 .Property(p => p.Endpoint)
+                .HasMaxLength(800)
                 .IsRequired();
 
             modelBuilder.Entity<UserNotificationPushSubscription>()

--- a/src/Recollections.Accounts.Data/Migrations/20260406093000_Notifications.cs
+++ b/src/Recollections.Accounts.Data/Migrations/20260406093000_Notifications.cs
@@ -19,7 +19,7 @@ namespace Neptuo.Recollections.Accounts.Migrations
                     Id = table.Column<int>(nullable: false)
                         .Annotation("Sqlite:Autoincrement", true),
                     UserId = table.Column<string>(maxLength: 36, nullable: false),
-                    Endpoint = table.Column<string>(nullable: false),
+                    Endpoint = table.Column<string>(maxLength: 800, nullable: false),
                     P256dh = table.Column<string>(nullable: false),
                     Auth = table.Column<string>(nullable: false),
                     CreatedAt = table.Column<DateTime>(nullable: false),

--- a/src/Recollections.Accounts.Data/Migrations/20260406093000_Notifications.cs
+++ b/src/Recollections.Accounts.Data/Migrations/20260406093000_Notifications.cs
@@ -17,7 +17,8 @@ namespace Neptuo.Recollections.Accounts.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
+                        .Annotation("Sqlite:Autoincrement", true)
+                        .Annotation("SqlServer:Identity", "1, 1"),
                     UserId = table.Column<string>(maxLength: 36, nullable: false),
                     Endpoint = table.Column<string>(maxLength: 800, nullable: false),
                     P256dh = table.Column<string>(nullable: false),

--- a/src/Recollections.Accounts.Data/Migrations/20260408052436_ImmediateNewEntriesDispatch.Designer.cs
+++ b/src/Recollections.Accounts.Data/Migrations/20260408052436_ImmediateNewEntriesDispatch.Designer.cs
@@ -296,6 +296,7 @@ namespace Neptuo.Recollections.Accounts.Migrations
 
                     b.Property<string>("Endpoint")
                         .IsRequired()
+                        .HasMaxLength(800)
                         .HasColumnType("TEXT");
 
                     b.Property<DateTime>("LastSeenAt")

--- a/src/Recollections.Accounts.Data/Migrations/20260408052436_ImmediateNewEntriesDispatch.cs
+++ b/src/Recollections.Accounts.Data/Migrations/20260408052436_ImmediateNewEntriesDispatch.cs
@@ -17,12 +17,12 @@ namespace Neptuo.Recollections.Accounts.Migrations
                 schema: Schema.Name,
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                    Id = table.Column<int>(nullable: false)
                         .Annotation("Sqlite:Autoincrement", true),
-                    UserId = table.Column<string>(type: "TEXT", nullable: false),
-                    EntryId = table.Column<string>(type: "TEXT", nullable: false),
-                    Created = table.Column<DateTime>(type: "TEXT", nullable: false),
-                    SentAt = table.Column<DateTime>(type: "TEXT", nullable: true)
+                    UserId = table.Column<string>(maxLength: 36, nullable: false),
+                    EntryId = table.Column<string>(maxLength: 36, nullable: false),
+                    Created = table.Column<DateTime>(nullable: false),
+                    SentAt = table.Column<DateTime>(nullable: true)
                 },
                 constraints: table =>
                 {

--- a/src/Recollections.Accounts.Data/Migrations/20260408052436_ImmediateNewEntriesDispatch.cs
+++ b/src/Recollections.Accounts.Data/Migrations/20260408052436_ImmediateNewEntriesDispatch.cs
@@ -18,7 +18,8 @@ namespace Neptuo.Recollections.Accounts.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
+                        .Annotation("Sqlite:Autoincrement", true)
+                        .Annotation("SqlServer:Identity", "1, 1"),
                     UserId = table.Column<string>(maxLength: 36, nullable: false),
                     EntryId = table.Column<string>(maxLength: 36, nullable: false),
                     Created = table.Column<DateTime>(nullable: false),

--- a/src/Recollections.Accounts.Data/Migrations/DataContextModelSnapshot.cs
+++ b/src/Recollections.Accounts.Data/Migrations/DataContextModelSnapshot.cs
@@ -293,6 +293,7 @@ namespace Neptuo.Recollections.Accounts.Migrations
 
                     b.Property<string>("Endpoint")
                         .IsRequired()
+                        .HasMaxLength(800)
                         .HasColumnType("TEXT");
 
                     b.Property<DateTime>("LastSeenAt")

--- a/src/Recollections.DbMigrationApplier/Program.cs
+++ b/src/Recollections.DbMigrationApplier/Program.cs
@@ -16,6 +16,7 @@ namespace Neptuo.Recollections
             {
                 if (args.Length == 0)
                 {
+                    Console.WriteLine("Enter connection string to database to migrate:");
                     connectionString = Console.ReadLine();
                 }
                 else if (args.Length != 1)

--- a/src/Recollections.Entries.Data/Migrations/20260414135907_EntryTrackBlob.cs
+++ b/src/Recollections.Entries.Data/Migrations/20260414135907_EntryTrackBlob.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Neptuo.Recollections.Migrations;
 
 #nullable disable
 
 namespace Neptuo.Recollections.Entries.Migrations
 {
     /// <inheritdoc />
-    public partial class EntryTrackBlob : Migration
+    public partial class EntryTrackBlob : MigrationWithSchema<DataContext>
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -13,31 +14,31 @@ namespace Neptuo.Recollections.Entries.Migrations
             migrationBuilder.AddColumn<double>(
                 name: "TrackAltitude",
                 table: "Entries",
-                type: "REAL",
+                schema: Schema.Name,
                 nullable: true);
 
             migrationBuilder.AddColumn<string>(
                 name: "TrackData",
                 table: "Entries",
-                type: "TEXT",
+                schema: Schema.Name,
                 nullable: true);
 
             migrationBuilder.AddColumn<double>(
                 name: "TrackLatitude",
                 table: "Entries",
-                type: "REAL",
+                schema: Schema.Name,
                 nullable: true);
 
             migrationBuilder.AddColumn<double>(
                 name: "TrackLongitude",
                 table: "Entries",
-                type: "REAL",
+                schema: Schema.Name,
                 nullable: true);
 
             migrationBuilder.AddColumn<int>(
                 name: "TrackPointCount",
                 table: "Entries",
-                type: "INTEGER",
+                schema: Schema.Name,
                 nullable: true);
         }
 
@@ -46,22 +47,27 @@ namespace Neptuo.Recollections.Entries.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "TrackAltitude",
+                schema: Schema.Name,
                 table: "Entries");
 
             migrationBuilder.DropColumn(
                 name: "TrackData",
+                schema: Schema.Name,
                 table: "Entries");
 
             migrationBuilder.DropColumn(
                 name: "TrackLatitude",
+                schema: Schema.Name,
                 table: "Entries");
 
             migrationBuilder.DropColumn(
                 name: "TrackLongitude",
+                schema: Schema.Name,
                 table: "Entries");
 
             migrationBuilder.DropColumn(
                 name: "TrackPointCount",
+                schema: Schema.Name,
                 table: "Entries");
         }
     }

--- a/src/Recollections.Entries.Data/Migrations/20260415073308_EntryTrackTotalElevation.cs
+++ b/src/Recollections.Entries.Data/Migrations/20260415073308_EntryTrackTotalElevation.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Neptuo.Recollections.Migrations;
 
 #nullable disable
 
 namespace Neptuo.Recollections.Entries.Migrations
 {
     /// <inheritdoc />
-    public partial class EntryTrackTotalElevation : Migration
+    public partial class EntryTrackTotalElevation : MigrationWithSchema<DataContext>
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -13,7 +14,7 @@ namespace Neptuo.Recollections.Entries.Migrations
             migrationBuilder.AddColumn<double>(
                 name: "TrackTotalElevation",
                 table: "Entries",
-                type: "REAL",
+                schema: Schema.Name,
                 nullable: true);
         }
 
@@ -22,6 +23,7 @@ namespace Neptuo.Recollections.Entries.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "TrackTotalElevation",
+                schema: Schema.Name,
                 table: "Entries");
         }
     }

--- a/src/Recollections.Entries.Data/Migrations/20260415084331_EntryTrackTotalDistance.cs
+++ b/src/Recollections.Entries.Data/Migrations/20260415084331_EntryTrackTotalDistance.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Neptuo.Recollections.Migrations;
 
 #nullable disable
 
 namespace Neptuo.Recollections.Entries.Migrations
 {
     /// <inheritdoc />
-    public partial class EntryTrackTotalDistance : Migration
+    public partial class EntryTrackTotalDistance : MigrationWithSchema<DataContext>
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -13,7 +14,7 @@ namespace Neptuo.Recollections.Entries.Migrations
             migrationBuilder.AddColumn<double>(
                 name: "TrackTotalDistance",
                 table: "Entries",
-                type: "REAL",
+                schema: Schema.Name,
                 nullable: true);
         }
 
@@ -22,6 +23,7 @@ namespace Neptuo.Recollections.Entries.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "TrackTotalDistance",
+                schema: Schema.Name,
                 table: "Entries");
         }
     }


### PR DESCRIPTION
Migrations were scaffolded against SQLite and failed on Azure SQL due to: (1) type mismatch on FK — UserId used TEXT type incompatible with nvarchar(36) on AspNetUsers.Id, (2) index on nvarchar(max) — EntryId had no maxLength so SQL Server mapped it to nvarchar(max) which can't be an index key, (3) missing schema — three track migrations inherited from Migration instead of MigrationWithSchema and lacked schema parameter. Fixed by removing hardcoded SQLite types, adding maxLength: 36, and using MigrationWithSchema<DataContext> with schema: Schema.Name.