### PR TITLE
Add sharing visibility endpoint test coverage (#466)

### DIFF
--- a/src/Recollections.Accounts/DbConnectionProvider.cs
+++ b/src/Recollections.Accounts/DbConnectionProvider.cs
@@ -18,6 +18,9 @@ public class DbConnectionProvider : IConnectionProvider
 
     public async Task<ConnectedUsersModel> GetConnectedUsersForAsync(string userId)
     {
+        if (string.IsNullOrWhiteSpace(userId))
+            return new(Array.Empty<string>(), Array.Empty<string>());
+
         IReadOnlyDictionary<string, ConnectedUsersModel> models = await GetConnectedUsersForAsync([userId]);
         return models.TryGetValue(userId, out ConnectedUsersModel connectedUsers)
             ? connectedUsers

--- a/src/Recollections.Api.Tests/Infrastructure/DatabaseSeeder.cs
+++ b/src/Recollections.Api.Tests/Infrastructure/DatabaseSeeder.cs
@@ -201,6 +201,41 @@ public static class DatabaseSeeder
         return image;
     }
 
+    public static async Task<Video> SeedVideo(
+        EntriesDataContext db,
+        string videoId,
+        Entry entry,
+        string name = null,
+        DateTime? when = null,
+        double? latitude = null,
+        double? longitude = null,
+        double? altitude = null)
+    {
+        var video = new Video
+        {
+            Id = videoId,
+            Entry = entry,
+            Name = name ?? $"Video {videoId}",
+            FileName = $"{videoId}.mp4",
+            ContentType = "video/mp4",
+            Created = when ?? entry.When,
+            When = when ?? entry.When,
+            OriginalWidth = 1920,
+            OriginalHeight = 1080,
+            Location = latitude != null && longitude != null
+                ? new MediaLocation
+                {
+                    Latitude = latitude,
+                    Longitude = longitude,
+                    Altitude = altitude,
+                }
+                : null,
+        };
+        db.Videos.Add(video);
+        await db.SaveChangesAsync();
+        return video;
+    }
+
     public static async Task SeedEntryShare(EntriesDataContext db, string entryId, string userId, Permission permission)
     {
         db.EntryShares.Add(new EntryShare(entryId, userId) { Permission = (int)permission });

--- a/src/Recollections.Api.Tests/Sharing/BeingVisibilityAccessTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/BeingVisibilityAccessTests.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using Neptuo.Recollections.Entries;
+using Neptuo.Recollections.Entries.Stories;
+using Neptuo.Recollections.Sharing;
+using Neptuo.Recollections.Tests.Infrastructure;
+using Xunit;
+
+namespace Neptuo.Recollections.Tests.Sharing;
+
+/// <summary>
+/// Covers anonymous / stranger / public-reader visibility for being-rooted read endpoints
+/// that the existing suite only exercises as an authenticated connected reader:
+/// /api/beings/{beingId}/timeline, /stories, /map.
+/// </summary>
+public class BeingVisibilityAccessTests : IClassFixture<ApiFactory>, IAsyncLifetime
+{
+    private readonly ApiFactory factory;
+
+    private const string OwnerUserId = "bvi-owner-id";
+    private const string OwnerUserName = "bviowner";
+    private const string StrangerUserId = "bvi-stranger-id";
+    private const string StrangerUserName = "bvistranger";
+
+    private const string PrivateBeingId = "bvi-being-private";
+    private const string PublicBeingId = "bvi-being-public";
+
+    private const string PublicEntryId = "bvi-entry-public";
+    private const string PrivateInheritedEntryId = "bvi-entry-private-inherited";
+    private const string PublicStoryId = "bvi-story-public";
+
+    public BeingVisibilityAccessTests(ApiFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await factory.SeedAsync(nameof(BeingVisibilityAccessTests), async (accountsDb, entriesDb) =>
+        {
+            await DatabaseSeeder.SeedUser(accountsDb, OwnerUserId, OwnerUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, StrangerUserId, StrangerUserName);
+
+            await DatabaseSeeder.SeedBeing(entriesDb, PrivateBeingId, OwnerUserId, isSharingInherited: false);
+
+            var publicBeing = await DatabaseSeeder.SeedBeing(entriesDb, PublicBeingId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedBeingShare(entriesDb, PublicBeingId, ShareStatusService.PublicUserId, Permission.Read);
+
+            var publicStory = await DatabaseSeeder.SeedStory(entriesDb, PublicStoryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedStoryShare(entriesDb, PublicStoryId, ShareStatusService.PublicUserId, Permission.Read);
+
+            var publicEntry = await DatabaseSeeder.SeedEntry(
+                entriesDb,
+                PublicEntryId,
+                OwnerUserId,
+                isSharingInherited: false,
+                story: publicStory,
+                when: new DateTime(2024, 10, 1, 10, 0, 0, DateTimeKind.Utc));
+            await DatabaseSeeder.SeedEntryShare(entriesDb, PublicEntryId, ShareStatusService.PublicUserId, Permission.Read);
+            await DatabaseSeeder.SeedEntryLocation(entriesDb, publicEntry, 48.2, 16.3);
+
+            var inheritedEntry = await DatabaseSeeder.SeedEntry(
+                entriesDb,
+                PrivateInheritedEntryId,
+                OwnerUserId,
+                isSharingInherited: true,
+                when: new DateTime(2024, 10, 2, 10, 0, 0, DateTimeKind.Utc));
+
+            publicEntry.Beings.Add(publicBeing);
+            inheritedEntry.Beings.Add(publicBeing);
+
+            await entriesDb.SaveChangesAsync();
+        });
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    public static IEnumerable<object[]> PrivateBeingRoutes()
+    {
+        yield return new object[] { $"/api/beings/{PrivateBeingId}/timeline?offset=0&count=20" };
+        yield return new object[] { $"/api/beings/{PrivateBeingId}/stories" };
+        yield return new object[] { $"/api/beings/{PrivateBeingId}/map" };
+    }
+
+    public static IEnumerable<object[]> PublicBeingRoutes()
+    {
+        yield return new object[] { $"/api/beings/{PublicBeingId}/timeline?offset=0&count=20" };
+        yield return new object[] { $"/api/beings/{PublicBeingId}/stories" };
+        yield return new object[] { $"/api/beings/{PublicBeingId}/map" };
+    }
+
+    [Theory, MemberData(nameof(PrivateBeingRoutes))]
+    public async Task PrivateBeing_AsStranger_ReturnsUnauthorized(string route)
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync(route);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory, MemberData(nameof(PrivateBeingRoutes))]
+    public async Task PrivateBeing_AsAnonymous_ReturnsUnauthorized(string route)
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync(route);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory, MemberData(nameof(PublicBeingRoutes))]
+    public async Task PublicBeing_AsAnonymous_ReturnsOk(string route)
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync(route);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PublicBeing_Timeline_AsAnonymous_ReturnsEntriesTaggedWithPublicBeing()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/beings/{PublicBeingId}/timeline?offset=0&count=20");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var page = await response.ReadJsonAsync<PageableList<EntryListModel>>();
+        var entryIds = page.Models.Select(e => e.Id).ToList();
+
+        // Both tagged entries become anonymously accessible through the public being association.
+        Assert.Contains(PublicEntryId, entryIds);
+        Assert.Contains(PrivateInheritedEntryId, entryIds);
+    }
+
+    [Fact]
+    public async Task PublicBeing_Stories_AsAnonymous_ReturnsOnlyStoriesFromAccessibleEntries()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/beings/{PublicBeingId}/stories");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<StoryListModel>>();
+        var storyIds = models.Select(m => m.Id).ToList();
+
+        Assert.Contains(PublicStoryId, storyIds);
+        Assert.Single(models);
+    }
+}

--- a/src/Recollections.Api.Tests/Sharing/EntryBeingVisibilityTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/EntryBeingVisibilityTests.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using Neptuo.Recollections.Entries;
+using Neptuo.Recollections.Sharing;
+using Neptuo.Recollections.Tests.Infrastructure;
+using Xunit;
+
+namespace Neptuo.Recollections.Tests.Sharing;
+
+public class EntryBeingVisibilityTests : IClassFixture<ApiFactory>, IAsyncLifetime
+{
+    private readonly ApiFactory factory;
+
+    private const string OwnerUserId = "ebv-owner-id";
+    private const string OwnerUserName = "ebvowner";
+    private const string ReaderUserId = "ebv-reader-id";
+    private const string ReaderUserName = "ebvreader";
+    private const string StrangerUserId = "ebv-stranger-id";
+    private const string StrangerUserName = "ebvstranger";
+
+    private const string PrivateEntryId = "ebv-entry-private";
+    private const string PublicEntryId = "ebv-entry-public";
+    private const string InheritedEntryId = "ebv-entry-inherited";
+
+    private const string PublicBeingId = "ebv-being-public";
+    private const string PrivateBeingId = "ebv-being-private";
+    private const string InheritedBeingId = "ebv-being-inherited";
+
+    public EntryBeingVisibilityTests(ApiFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await factory.SeedAsync(nameof(EntryBeingVisibilityTests), async (accountsDb, entriesDb) =>
+        {
+            await DatabaseSeeder.SeedUser(accountsDb, OwnerUserId, OwnerUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, ReaderUserId, ReaderUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, StrangerUserId, StrangerUserName);
+
+            await DatabaseSeeder.SeedConnection(accountsDb, OwnerUserId, ReaderUserId,
+                permission1: Permission.Read, permission2: Permission.Read);
+
+            var publicBeing = await DatabaseSeeder.SeedBeing(entriesDb, PublicBeingId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedBeingShare(entriesDb, PublicBeingId, ShareStatusService.PublicUserId, Permission.Read);
+
+            var privateBeing = await DatabaseSeeder.SeedBeing(entriesDb, PrivateBeingId, OwnerUserId, isSharingInherited: false);
+            var inheritedBeing = await DatabaseSeeder.SeedBeing(entriesDb, InheritedBeingId, OwnerUserId, isSharingInherited: true);
+
+            // Private entry with two attached beings
+            var privateEntry = await DatabaseSeeder.SeedEntry(entriesDb, PrivateEntryId, OwnerUserId, isSharingInherited: false);
+            privateEntry.Beings.Add(publicBeing);
+            privateEntry.Beings.Add(privateBeing);
+
+            // Public entry with all three beings attached
+            var publicEntry = await DatabaseSeeder.SeedEntry(entriesDb, PublicEntryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedEntryShare(entriesDb, PublicEntryId, ShareStatusService.PublicUserId, Permission.Read);
+            publicEntry.Beings.Add(publicBeing);
+            publicEntry.Beings.Add(privateBeing);
+            publicEntry.Beings.Add(inheritedBeing);
+
+            // Inherited entry (reader connected to owner) with two beings
+            var inheritedEntry = await DatabaseSeeder.SeedEntry(entriesDb, InheritedEntryId, OwnerUserId, isSharingInherited: true);
+            inheritedEntry.Beings.Add(inheritedBeing);
+            inheritedEntry.Beings.Add(privateBeing);
+
+            await entriesDb.SaveChangesAsync();
+        });
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task PrivateEntry_AsStranger_ReturnsUnauthorized()
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/beings");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PrivateEntry_AsAnonymous_ReturnsUnauthorized()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/beings");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PublicEntry_AsAnonymous_ReturnsOnlyPublicShareableBeings()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PublicEntryId}/beings");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<EntryBeingModel>>();
+        var beingIds = models.Select(m => m.Id).ToList();
+
+        Assert.Contains(PublicBeingId, beingIds);
+        Assert.DoesNotContain(PrivateBeingId, beingIds);
+        Assert.DoesNotContain(InheritedBeingId, beingIds);
+        Assert.Single(models);
+    }
+
+    [Fact]
+    public async Task InheritedEntry_AsConnectedReader_ReturnsBeingsVisibleViaConnection()
+    {
+        var client = factory.CreateClientForUser(ReaderUserId, ReaderUserName);
+        var response = await client.GetAsync($"/api/entries/{InheritedEntryId}/beings");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<EntryBeingModel>>();
+        var beingIds = models.Select(m => m.Id).ToList();
+
+        Assert.Contains(InheritedBeingId, beingIds);
+        Assert.DoesNotContain(PrivateBeingId, beingIds);
+        Assert.Single(models);
+    }
+
+    [Fact]
+    public async Task PublicEntry_AsOwner_ReturnsAllAttachedBeings()
+    {
+        var client = factory.CreateClientForUser(OwnerUserId, OwnerUserName);
+        var response = await client.GetAsync($"/api/entries/{PublicEntryId}/beings");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<EntryBeingModel>>();
+        var beingIds = models.Select(m => m.Id).ToList();
+
+        Assert.Contains(PublicBeingId, beingIds);
+        Assert.Contains(PrivateBeingId, beingIds);
+        Assert.Contains(InheritedBeingId, beingIds);
+        Assert.Equal(3, models.Count);
+    }
+}

--- a/src/Recollections.Api.Tests/Sharing/EntryImageDetailAccessTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/EntryImageDetailAccessTests.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using Neptuo.Recollections.Entries;
+using Neptuo.Recollections.Sharing;
+using Neptuo.Recollections.Tests.Infrastructure;
+using Xunit;
+
+namespace Neptuo.Recollections.Tests.Sharing;
+
+/// <summary>
+/// Covers the authorization gate for image detail and image file routes.
+/// File content routes return <c>404 NotFound</c> when auth passes because no real files
+/// are seeded on disk — that is enough to prove the authorization behavior.
+/// </summary>
+public class EntryImageDetailAccessTests : IClassFixture<ApiFactory>, IAsyncLifetime
+{
+    private readonly ApiFactory factory;
+
+    private const string OwnerUserId = "eid-owner-id";
+    private const string OwnerUserName = "eidowner";
+    private const string ReaderUserId = "eid-reader-id";
+    private const string ReaderUserName = "eidreader";
+    private const string StrangerUserId = "eid-stranger-id";
+    private const string StrangerUserName = "eidstranger";
+
+    private const string PrivateEntryId = "eid-entry-private";
+    private const string SharedEntryId = "eid-entry-shared";
+    private const string PublicEntryId = "eid-entry-public";
+
+    private const string PrivateImageId = "eid-image-private";
+    private const string SharedImageId = "eid-image-shared";
+    private const string PublicImageId = "eid-image-public";
+
+    public EntryImageDetailAccessTests(ApiFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await factory.SeedAsync(nameof(EntryImageDetailAccessTests), async (accountsDb, entriesDb) =>
+        {
+            await DatabaseSeeder.SeedUser(accountsDb, OwnerUserId, OwnerUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, ReaderUserId, ReaderUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, StrangerUserId, StrangerUserName);
+
+            await DatabaseSeeder.SeedConnection(accountsDb, OwnerUserId, ReaderUserId,
+                permission1: Permission.Read, permission2: Permission.Read);
+
+            var privateEntry = await DatabaseSeeder.SeedEntry(entriesDb, PrivateEntryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedImage(entriesDb, PrivateImageId, privateEntry);
+
+            var sharedEntry = await DatabaseSeeder.SeedEntry(entriesDb, SharedEntryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedEntryShare(entriesDb, SharedEntryId, ReaderUserId, Permission.Read);
+            await DatabaseSeeder.SeedImage(entriesDb, SharedImageId, sharedEntry);
+
+            var publicEntry = await DatabaseSeeder.SeedEntry(entriesDb, PublicEntryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedEntryShare(entriesDb, PublicEntryId, ShareStatusService.PublicUserId, Permission.Read);
+            await DatabaseSeeder.SeedImage(entriesDb, PublicImageId, publicEntry);
+        });
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // ===== Detail =====
+
+    [Fact]
+    public async Task Detail_SharedEntry_AsOwner_ReturnsOk()
+    {
+        var client = factory.CreateClientForUser(OwnerUserId, OwnerUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/images/{SharedImageId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.ReadJsonAsync<AuthorizedModel<ImageModel>>();
+        Assert.Equal(SharedImageId, result.Model.Id);
+        Assert.Equal(OwnerUserId, result.OwnerId);
+        Assert.Equal(Permission.CoOwner, result.UserPermission);
+    }
+
+    [Fact]
+    public async Task Detail_SharedEntry_AsExplicitReader_ReturnsReadPermission()
+    {
+        var client = factory.CreateClientForUser(ReaderUserId, ReaderUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/images/{SharedImageId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.ReadJsonAsync<AuthorizedModel<ImageModel>>();
+        Assert.Equal(SharedImageId, result.Model.Id);
+        Assert.Equal(Permission.Read, result.UserPermission);
+    }
+
+    [Fact]
+    public async Task Detail_PrivateEntry_AsStranger_ReturnsUnauthorized()
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/images/{PrivateImageId}");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Detail_PrivateEntry_AsAnonymous_ReturnsUnauthorized()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/images/{PrivateImageId}");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Detail_PublicEntry_AsAnonymous_ReturnsReadPermission()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PublicEntryId}/images/{PublicImageId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.ReadJsonAsync<AuthorizedModel<ImageModel>>();
+        Assert.Equal(PublicImageId, result.Model.Id);
+        Assert.Equal(Permission.Read, result.UserPermission);
+    }
+
+    // ===== File routes (preview, thumbnail, original) =====
+
+    public static IEnumerable<object[]> FileRoutes()
+    {
+        yield return new object[] { "preview" };
+        yield return new object[] { "thumbnail" };
+        yield return new object[] { "original" };
+    }
+
+    [Theory, MemberData(nameof(FileRoutes))]
+    public async Task File_PrivateEntry_AsStranger_ReturnsUnauthorized(string route)
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/images/{PrivateImageId}/{route}");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory, MemberData(nameof(FileRoutes))]
+    public async Task File_PrivateEntry_AsAnonymous_ReturnsUnauthorized(string route)
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/images/{PrivateImageId}/{route}");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory, MemberData(nameof(FileRoutes))]
+    public async Task File_PublicEntry_AsAnonymous_AuthorizationGatePasses(string route)
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PublicEntryId}/images/{PublicImageId}/{route}");
+
+        // Auth passed → controller reaches file storage, which has no file → 404.
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory, MemberData(nameof(FileRoutes))]
+    public async Task File_SharedEntry_AsExplicitReader_AuthorizationGatePasses(string route)
+    {
+        var client = factory.CreateClientForUser(ReaderUserId, ReaderUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/images/{SharedImageId}/{route}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory, MemberData(nameof(FileRoutes))]
+    public async Task File_SharedEntry_AsOwner_AuthorizationGatePasses(string route)
+    {
+        var client = factory.CreateClientForUser(OwnerUserId, OwnerUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/images/{SharedImageId}/{route}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/src/Recollections.Api.Tests/Sharing/EntryMediaAccessTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/EntryMediaAccessTests.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using Neptuo.Recollections.Entries;
+using Neptuo.Recollections.Sharing;
+using Neptuo.Recollections.Tests.Infrastructure;
+using Xunit;
+
+namespace Neptuo.Recollections.Tests.Sharing;
+
+/// <summary>
+/// Covers the visibility gate for entry-rooted media list endpoints:
+/// <c>GET /api/entries/{entryId}/media</c> and <c>GET /api/entries/{entryId}/images</c>.
+/// </summary>
+public class EntryMediaAccessTests : IClassFixture<ApiFactory>, IAsyncLifetime
+{
+    private readonly ApiFactory factory;
+
+    private const string OwnerUserId = "ema-owner-id";
+    private const string OwnerUserName = "emaowner";
+    private const string ReaderUserId = "ema-reader-id";
+    private const string ReaderUserName = "emareader";
+    private const string StrangerUserId = "ema-stranger-id";
+    private const string StrangerUserName = "emastranger";
+
+    private const string PrivateEntryId = "ema-entry-private";
+    private const string SharedEntryId = "ema-entry-shared";
+    private const string PublicEntryId = "ema-entry-public";
+
+    private const string PrivateEntryImageId = "ema-image-private";
+    private const string SharedEntryImageId = "ema-image-shared";
+    private const string PublicEntryImageId = "ema-image-public";
+
+    public EntryMediaAccessTests(ApiFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await factory.SeedAsync(nameof(EntryMediaAccessTests), async (accountsDb, entriesDb) =>
+        {
+            await DatabaseSeeder.SeedUser(accountsDb, OwnerUserId, OwnerUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, ReaderUserId, ReaderUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, StrangerUserId, StrangerUserName);
+
+            await DatabaseSeeder.SeedConnection(accountsDb, OwnerUserId, ReaderUserId,
+                permission1: Permission.Read, permission2: Permission.Read);
+
+            var privateEntry = await DatabaseSeeder.SeedEntry(entriesDb, PrivateEntryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedImage(entriesDb, PrivateEntryImageId, privateEntry);
+
+            var sharedEntry = await DatabaseSeeder.SeedEntry(entriesDb, SharedEntryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedEntryShare(entriesDb, SharedEntryId, ReaderUserId, Permission.Read);
+            await DatabaseSeeder.SeedImage(entriesDb, SharedEntryImageId, sharedEntry);
+
+            var publicEntry = await DatabaseSeeder.SeedEntry(entriesDb, PublicEntryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedEntryShare(entriesDb, PublicEntryId, ShareStatusService.PublicUserId, Permission.Read);
+            await DatabaseSeeder.SeedImage(entriesDb, PublicEntryImageId, publicEntry);
+        });
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // ===== /media =====
+
+    [Fact]
+    public async Task Media_PrivateEntry_AsStranger_ReturnsUnauthorized()
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/media");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Media_PrivateEntry_AsAnonymous_ReturnsUnauthorized()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/media");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Media_SharedEntry_AsOwner_ReturnsSharedImage()
+    {
+        var client = factory.CreateClientForUser(OwnerUserId, OwnerUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/media");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<MediaModel>>();
+        Assert.Single(models);
+        Assert.Equal("image", models[0].Type);
+        Assert.Equal(SharedEntryImageId, models[0].Image?.Id);
+    }
+
+    [Fact]
+    public async Task Media_SharedEntry_AsExplicitReader_ReturnsSharedImage()
+    {
+        var client = factory.CreateClientForUser(ReaderUserId, ReaderUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/media");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<MediaModel>>();
+        Assert.Single(models);
+        Assert.Equal(SharedEntryImageId, models[0].Image?.Id);
+    }
+
+    [Fact]
+    public async Task Media_PublicEntry_AsAnonymous_ReturnsPublicImage()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PublicEntryId}/media");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<MediaModel>>();
+        Assert.Single(models);
+        Assert.Equal(PublicEntryImageId, models[0].Image?.Id);
+    }
+
+    // ===== /images =====
+
+    [Fact]
+    public async Task Images_PrivateEntry_AsStranger_ReturnsUnauthorized()
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/images");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Images_PrivateEntry_AsAnonymous_ReturnsUnauthorized()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/images");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Images_SharedEntry_AsExplicitReader_ReturnsSharedImage()
+    {
+        var client = factory.CreateClientForUser(ReaderUserId, ReaderUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/images");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<ImageModel>>();
+        Assert.Single(models);
+        Assert.Equal(SharedEntryImageId, models[0].Id);
+    }
+
+    [Fact]
+    public async Task Images_PublicEntry_AsAnonymous_ReturnsPublicImage()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PublicEntryId}/images");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<ImageModel>>();
+        Assert.Single(models);
+        Assert.Equal(PublicEntryImageId, models[0].Id);
+    }
+
+    [Fact]
+    public async Task Images_PublicEntry_AsOwner_ReturnsPublicImage()
+    {
+        var client = factory.CreateClientForUser(OwnerUserId, OwnerUserName);
+        var response = await client.GetAsync($"/api/entries/{PublicEntryId}/images");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<ImageModel>>();
+        Assert.Single(models);
+        Assert.Equal(PublicEntryImageId, models[0].Id);
+    }
+}

--- a/src/Recollections.Api.Tests/Sharing/EntryStoryEndpointTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/EntryStoryEndpointTests.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using Neptuo.Recollections.Entries;
+using Neptuo.Recollections.Sharing;
+using Neptuo.Recollections.Tests.Infrastructure;
+using Xunit;
+
+namespace Neptuo.Recollections.Tests.Sharing;
+
+public class EntryStoryEndpointTests : IClassFixture<ApiFactory>, IAsyncLifetime
+{
+    private readonly ApiFactory factory;
+
+    private const string OwnerUserId = "es-owner-id";
+    private const string OwnerUserName = "esowner";
+    private const string ReaderUserId = "es-reader-id";
+    private const string ReaderUserName = "esreader";
+    private const string StrangerUserId = "es-stranger-id";
+    private const string StrangerUserName = "esstranger";
+
+    private const string StoryId = "es-story-id";
+    private const string StoryTitle = "Story es-story-id";
+    private const string ChapterId = "es-chapter-id";
+    private const string ChapterTitle = "Chapter es-chapter-id";
+
+    private const string SharedEntryId = "es-entry-shared";
+    private const string PrivateEntryId = "es-entry-private";
+    private const string PublicEntryId = "es-entry-public";
+    private const string PublicChapterEntryId = "es-entry-public-chapter";
+
+    public EntryStoryEndpointTests(ApiFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await factory.SeedAsync(nameof(EntryStoryEndpointTests), async (accountsDb, entriesDb) =>
+        {
+            await DatabaseSeeder.SeedUser(accountsDb, OwnerUserId, OwnerUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, ReaderUserId, ReaderUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, StrangerUserId, StrangerUserName);
+
+            await DatabaseSeeder.SeedConnection(accountsDb, OwnerUserId, ReaderUserId,
+                permission1: Permission.Read, permission2: Permission.Read);
+
+            var story = await DatabaseSeeder.SeedStory(entriesDb, StoryId, OwnerUserId, isSharingInherited: false);
+            story.Title = StoryTitle;
+            var chapter = await DatabaseSeeder.SeedChapter(entriesDb, ChapterId, story, ChapterTitle);
+            await entriesDb.SaveChangesAsync();
+
+            // Shared entry (explicit share to reader) with story
+            await DatabaseSeeder.SeedEntry(entriesDb, SharedEntryId, OwnerUserId, isSharingInherited: false, story: story);
+            await DatabaseSeeder.SeedEntryShare(entriesDb, SharedEntryId, ReaderUserId, Permission.Read);
+
+            // Private entry (no reader share) with story
+            await DatabaseSeeder.SeedEntry(entriesDb, PrivateEntryId, OwnerUserId, isSharingInherited: false, story: story);
+
+            // Public entry attached directly to story
+            await DatabaseSeeder.SeedEntry(entriesDb, PublicEntryId, OwnerUserId, isSharingInherited: false, story: story);
+            await DatabaseSeeder.SeedEntryShare(entriesDb, PublicEntryId, ShareStatusService.PublicUserId, Permission.Read);
+
+            // Public entry attached via chapter
+            await DatabaseSeeder.SeedEntry(entriesDb, PublicChapterEntryId, OwnerUserId, isSharingInherited: false, chapter: chapter);
+            await DatabaseSeeder.SeedEntryShare(entriesDb, PublicChapterEntryId, ShareStatusService.PublicUserId, Permission.Read);
+        });
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task SharedEntry_AsOwner_ReturnsStoryMetadata()
+    {
+        var client = factory.CreateClientForUser(OwnerUserId, OwnerUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/story");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var model = await response.ReadJsonAsync<EntryStoryModel>();
+        Assert.Equal(StoryId, model.StoryId);
+        Assert.Equal(StoryTitle, model.StoryTitle);
+        Assert.Null(model.ChapterId);
+    }
+
+    [Fact]
+    public async Task SharedEntry_AsExplicitReader_ReturnsStoryMetadata()
+    {
+        var client = factory.CreateClientForUser(ReaderUserId, ReaderUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/story");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var model = await response.ReadJsonAsync<EntryStoryModel>();
+        Assert.Equal(StoryId, model.StoryId);
+    }
+
+    [Fact]
+    public async Task SharedEntry_AsStranger_ReturnsUnauthorized()
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/story");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SharedEntry_AsAnonymous_ReturnsUnauthorized()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/story");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PrivateEntry_AsExplicitReader_ReturnsUnauthorized()
+    {
+        var client = factory.CreateClientForUser(ReaderUserId, ReaderUserName);
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/story");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PublicEntry_AsAnonymous_ReturnsStoryMetadata()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PublicEntryId}/story");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var model = await response.ReadJsonAsync<EntryStoryModel>();
+        Assert.Equal(StoryId, model.StoryId);
+        Assert.Equal(StoryTitle, model.StoryTitle);
+        Assert.Null(model.ChapterId);
+    }
+
+    [Fact]
+    public async Task PublicChapterEntry_AsAnonymous_ReturnsChapterMetadata()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PublicChapterEntryId}/story");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var model = await response.ReadJsonAsync<EntryStoryModel>();
+        Assert.Equal(StoryId, model.StoryId);
+        Assert.Equal(ChapterId, model.ChapterId);
+        Assert.Equal(ChapterTitle, model.ChapterTitle);
+    }
+}

--- a/src/Recollections.Api.Tests/Sharing/EntryVideoDetailAccessTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/EntryVideoDetailAccessTests.cs
@@ -1,0 +1,170 @@
+using System.Net;
+using Neptuo.Recollections.Entries;
+using Neptuo.Recollections.Sharing;
+using Neptuo.Recollections.Tests.Infrastructure;
+using Xunit;
+
+namespace Neptuo.Recollections.Tests.Sharing;
+
+/// <summary>
+/// Covers the authorization gate for video detail and video file routes.
+/// File content routes return <c>404 NotFound</c> when auth passes because no real files
+/// are seeded on disk — that is enough to prove the authorization behavior.
+/// </summary>
+public class EntryVideoDetailAccessTests : IClassFixture<ApiFactory>, IAsyncLifetime
+{
+    private readonly ApiFactory factory;
+
+    private const string OwnerUserId = "evd-owner-id";
+    private const string OwnerUserName = "evdowner";
+    private const string ReaderUserId = "evd-reader-id";
+    private const string ReaderUserName = "evdreader";
+    private const string StrangerUserId = "evd-stranger-id";
+    private const string StrangerUserName = "evdstranger";
+
+    private const string PrivateEntryId = "evd-entry-private";
+    private const string SharedEntryId = "evd-entry-shared";
+    private const string PublicEntryId = "evd-entry-public";
+
+    private const string PrivateVideoId = "evd-video-private";
+    private const string SharedVideoId = "evd-video-shared";
+    private const string PublicVideoId = "evd-video-public";
+
+    public EntryVideoDetailAccessTests(ApiFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await factory.SeedAsync(nameof(EntryVideoDetailAccessTests), async (accountsDb, entriesDb) =>
+        {
+            await DatabaseSeeder.SeedUser(accountsDb, OwnerUserId, OwnerUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, ReaderUserId, ReaderUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, StrangerUserId, StrangerUserName);
+
+            await DatabaseSeeder.SeedConnection(accountsDb, OwnerUserId, ReaderUserId,
+                permission1: Permission.Read, permission2: Permission.Read);
+
+            var privateEntry = await DatabaseSeeder.SeedEntry(entriesDb, PrivateEntryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedVideo(entriesDb, PrivateVideoId, privateEntry);
+
+            var sharedEntry = await DatabaseSeeder.SeedEntry(entriesDb, SharedEntryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedEntryShare(entriesDb, SharedEntryId, ReaderUserId, Permission.Read);
+            await DatabaseSeeder.SeedVideo(entriesDb, SharedVideoId, sharedEntry);
+
+            var publicEntry = await DatabaseSeeder.SeedEntry(entriesDb, PublicEntryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedEntryShare(entriesDb, PublicEntryId, ShareStatusService.PublicUserId, Permission.Read);
+            await DatabaseSeeder.SeedVideo(entriesDb, PublicVideoId, publicEntry);
+        });
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // ===== Detail =====
+
+    [Fact]
+    public async Task Detail_SharedEntry_AsOwner_ReturnsOk()
+    {
+        var client = factory.CreateClientForUser(OwnerUserId, OwnerUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/videos/{SharedVideoId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.ReadJsonAsync<AuthorizedModel<VideoModel>>();
+        Assert.Equal(SharedVideoId, result.Model.Id);
+        Assert.Equal(OwnerUserId, result.OwnerId);
+        Assert.Equal(Permission.CoOwner, result.UserPermission);
+    }
+
+    [Fact]
+    public async Task Detail_SharedEntry_AsExplicitReader_ReturnsReadPermission()
+    {
+        var client = factory.CreateClientForUser(ReaderUserId, ReaderUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/videos/{SharedVideoId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.ReadJsonAsync<AuthorizedModel<VideoModel>>();
+        Assert.Equal(SharedVideoId, result.Model.Id);
+        Assert.Equal(Permission.Read, result.UserPermission);
+    }
+
+    [Fact]
+    public async Task Detail_PrivateEntry_AsStranger_ReturnsUnauthorized()
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/videos/{PrivateVideoId}");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Detail_PrivateEntry_AsAnonymous_ReturnsUnauthorized()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/videos/{PrivateVideoId}");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Detail_PublicEntry_AsAnonymous_ReturnsReadPermission()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PublicEntryId}/videos/{PublicVideoId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.ReadJsonAsync<AuthorizedModel<VideoModel>>();
+        Assert.Equal(PublicVideoId, result.Model.Id);
+        Assert.Equal(Permission.Read, result.UserPermission);
+    }
+
+    // ===== File routes =====
+
+    public static IEnumerable<object[]> FileRoutes()
+    {
+        yield return new object[] { "thumbnail" };
+        yield return new object[] { "preview" };
+        yield return new object[] { "original" };
+    }
+
+    [Theory, MemberData(nameof(FileRoutes))]
+    public async Task File_PrivateEntry_AsStranger_ReturnsUnauthorized(string route)
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/videos/{PrivateVideoId}/{route}");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory, MemberData(nameof(FileRoutes))]
+    public async Task File_PrivateEntry_AsAnonymous_ReturnsUnauthorized(string route)
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PrivateEntryId}/videos/{PrivateVideoId}/{route}");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory, MemberData(nameof(FileRoutes))]
+    public async Task File_PublicEntry_AsAnonymous_AuthorizationGatePasses(string route)
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/entries/{PublicEntryId}/videos/{PublicVideoId}/{route}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory, MemberData(nameof(FileRoutes))]
+    public async Task File_SharedEntry_AsExplicitReader_AuthorizationGatePasses(string route)
+    {
+        var client = factory.CreateClientForUser(ReaderUserId, ReaderUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/videos/{SharedVideoId}/{route}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory, MemberData(nameof(FileRoutes))]
+    public async Task File_SharedEntry_AsOwner_AuthorizationGatePasses(string route)
+    {
+        var client = factory.CreateClientForUser(OwnerUserId, OwnerUserName);
+        var response = await client.GetAsync($"/api/entries/{SharedEntryId}/videos/{SharedVideoId}/{route}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/src/Recollections.Api.Tests/Sharing/ProfileAccessTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/ProfileAccessTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using Neptuo.Recollections.Accounts;
+using Neptuo.Recollections.Entries;
+using Neptuo.Recollections.Sharing;
+using Neptuo.Recollections.Tests.Infrastructure;
+using Xunit;
+
+namespace Neptuo.Recollections.Tests.Sharing;
+
+/// <summary>
+/// Covers the sharing/visibility behavior for <c>GET /api/profiles/{id}</c> and
+/// additional anonymous/stranger/public coverage for
+/// <c>GET /api/profiles/{id}/timeline/list</c>.
+/// </summary>
+public class ProfileAccessTests : IClassFixture<ApiFactory>, IAsyncLifetime
+{
+    private readonly ApiFactory factory;
+
+    private const string PublicProfileUserId = "pa-public-user-id";
+    private const string PublicProfileUserName = "papublicuser";
+    private const string PrivateProfileUserId = "pa-private-user-id";
+    private const string PrivateProfileUserName = "paprivateuser";
+    private const string ReaderUserId = "pa-reader-id";
+    private const string ReaderUserName = "pareader";
+    private const string StrangerUserId = "pa-stranger-id";
+    private const string StrangerUserName = "pastranger";
+
+    private const string PublicEntryId = "pa-entry-public";
+    private const string PrivateEntryId = "pa-entry-private";
+
+    public ProfileAccessTests(ApiFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await factory.SeedAsync(nameof(ProfileAccessTests), async (accountsDb, entriesDb) =>
+        {
+            await DatabaseSeeder.SeedUser(accountsDb, PublicProfileUserId, PublicProfileUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, PrivateProfileUserId, PrivateProfileUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, ReaderUserId, ReaderUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, StrangerUserId, StrangerUserName);
+
+            await DatabaseSeeder.SeedConnection(accountsDb, PublicProfileUserId, ReaderUserId,
+                permission1: Permission.Read, permission2: Permission.Read);
+
+            // Public profile: user being shared to PublicUserId
+            await DatabaseSeeder.SeedUserBeing(entriesDb, PublicProfileUserId, PublicProfileUserName);
+            await DatabaseSeeder.SeedBeingShare(entriesDb, PublicProfileUserId, ShareStatusService.PublicUserId, Permission.Read);
+            await DatabaseSeeder.SeedBeingShare(entriesDb, PublicProfileUserId, ReaderUserId, Permission.Read);
+
+            // Private profile: user being exists but is not shared to anyone
+            await DatabaseSeeder.SeedUserBeing(entriesDb, PrivateProfileUserId, PrivateProfileUserName);
+
+            // Entries on the public profile
+            await DatabaseSeeder.SeedEntry(entriesDb, PublicEntryId, PublicProfileUserId, isSharingInherited: false,
+                when: new DateTime(2024, 11, 1, 10, 0, 0, DateTimeKind.Utc));
+            await DatabaseSeeder.SeedEntryShare(entriesDb, PublicEntryId, ShareStatusService.PublicUserId, Permission.Read);
+
+            await DatabaseSeeder.SeedEntry(entriesDb, PrivateEntryId, PublicProfileUserId, isSharingInherited: false,
+                when: new DateTime(2024, 11, 2, 10, 0, 0, DateTimeKind.Utc));
+        });
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // ===== GET /api/profiles/{id} =====
+
+    [Fact]
+    public async Task Profile_AsOwner_ReturnsCoOwnerPermission()
+    {
+        var client = factory.CreateClientForUser(PublicProfileUserId, PublicProfileUserName);
+        var response = await client.GetAsync($"/api/profiles/{PublicProfileUserId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.ReadJsonAsync<AuthorizedModel<ProfileModel>>();
+        Assert.Equal(PublicProfileUserId, result.OwnerId);
+        Assert.Equal(Permission.CoOwner, result.UserPermission);
+    }
+
+    [Fact]
+    public async Task Profile_AsConnectedReader_ReturnsReadPermission()
+    {
+        var client = factory.CreateClientForUser(ReaderUserId, ReaderUserName);
+        var response = await client.GetAsync($"/api/profiles/{PublicProfileUserId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.ReadJsonAsync<AuthorizedModel<ProfileModel>>();
+        Assert.Equal(Permission.Read, result.UserPermission);
+    }
+
+    [Fact]
+    public async Task Profile_AsAnonymous_OnPublicProfile_ReturnsReadPermission()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/profiles/{PublicProfileUserId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.ReadJsonAsync<AuthorizedModel<ProfileModel>>();
+        Assert.Equal(Permission.Read, result.UserPermission);
+    }
+
+    [Fact]
+    public async Task Profile_AsStranger_OnPrivateProfile_ReturnsUnauthorized()
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync($"/api/profiles/{PrivateProfileUserId}");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Profile_AsAnonymous_OnPrivateProfile_ReturnsUnauthorized()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/profiles/{PrivateProfileUserId}");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // ===== GET /api/profiles/{id}/timeline/list =====
+
+    [Fact]
+    public async Task ProfileTimeline_AsStranger_OnPrivateProfile_ReturnsUnauthorized()
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync($"/api/profiles/{PrivateProfileUserId}/timeline/list?offset=0&count=20");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProfileTimeline_AsAnonymous_OnPrivateProfile_ReturnsUnauthorized()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/profiles/{PrivateProfileUserId}/timeline/list?offset=0&count=20");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProfileTimeline_AsAnonymous_OnPublicProfile_ReturnsOnlyPublicEntries()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/profiles/{PublicProfileUserId}/timeline/list?offset=0&count=20");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var page = await response.ReadJsonAsync<PageableList<EntryListModel>>();
+        var entryIds = page.Models.Select(e => e.Id).ToList();
+
+        Assert.Contains(PublicEntryId, entryIds);
+        Assert.DoesNotContain(PrivateEntryId, entryIds);
+        Assert.Single(page.Models);
+    }
+}

--- a/src/Recollections.Api.Tests/Sharing/StoryChaptersAccessTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/StoryChaptersAccessTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using Neptuo.Recollections.Entries;
+using Neptuo.Recollections.Entries.Stories;
+using Neptuo.Recollections.Sharing;
+using Neptuo.Recollections.Tests.Infrastructure;
+using Xunit;
+
+namespace Neptuo.Recollections.Tests.Sharing;
+
+public class StoryChaptersAccessTests : IClassFixture<ApiFactory>, IAsyncLifetime
+{
+    private readonly ApiFactory factory;
+
+    private const string OwnerUserId = "sc-owner-id";
+    private const string OwnerUserName = "scowner";
+    private const string ReaderUserId = "sc-reader-id";
+    private const string ReaderUserName = "screader";
+    private const string StrangerUserId = "sc-stranger-id";
+    private const string StrangerUserName = "scstranger";
+
+    private const string SharedStoryId = "sc-story-shared";
+    private const string PrivateStoryId = "sc-story-private";
+    private const string PublicStoryId = "sc-story-public";
+
+    private const string SharedChapterAId = "sc-shared-chapter-a";
+    private const string SharedChapterBId = "sc-shared-chapter-b";
+    private const string PrivateChapterId = "sc-private-chapter";
+    private const string PublicChapterId = "sc-public-chapter";
+
+    public StoryChaptersAccessTests(ApiFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await factory.SeedAsync(nameof(StoryChaptersAccessTests), async (accountsDb, entriesDb) =>
+        {
+            await DatabaseSeeder.SeedUser(accountsDb, OwnerUserId, OwnerUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, ReaderUserId, ReaderUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, StrangerUserId, StrangerUserName);
+
+            var sharedStory = await DatabaseSeeder.SeedStory(entriesDb, SharedStoryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedStoryShare(entriesDb, SharedStoryId, ReaderUserId, Permission.Read);
+            await DatabaseSeeder.SeedChapter(entriesDb, SharedChapterAId, sharedStory, title: "Shared Chapter A", order: 1);
+            await DatabaseSeeder.SeedChapter(entriesDb, SharedChapterBId, sharedStory, title: "Shared Chapter B", order: 2);
+
+            var privateStory = await DatabaseSeeder.SeedStory(entriesDb, PrivateStoryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedChapter(entriesDb, PrivateChapterId, privateStory, title: "Private Chapter");
+
+            var publicStory = await DatabaseSeeder.SeedStory(entriesDb, PublicStoryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedStoryShare(entriesDb, PublicStoryId, ShareStatusService.PublicUserId, Permission.Read);
+            await DatabaseSeeder.SeedChapter(entriesDb, PublicChapterId, publicStory, title: "Public Chapter");
+        });
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task SharedStoryChapters_AsOwner_ReturnsAllChapters()
+    {
+        var client = factory.CreateClientForUser(OwnerUserId, OwnerUserName);
+        var response = await client.GetAsync($"/api/stories/{SharedStoryId}/chapters");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<StoryChapterListModel>>();
+        var chapterIds = models.Select(m => m.Id).ToList();
+        Assert.Equal(2, models.Count);
+        Assert.Contains(SharedChapterAId, chapterIds);
+        Assert.Contains(SharedChapterBId, chapterIds);
+    }
+
+    [Fact]
+    public async Task SharedStoryChapters_AsExplicitReader_ReturnsAllChapters()
+    {
+        var client = factory.CreateClientForUser(ReaderUserId, ReaderUserName);
+        var response = await client.GetAsync($"/api/stories/{SharedStoryId}/chapters");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<StoryChapterListModel>>();
+        Assert.Equal(2, models.Count);
+    }
+
+    [Fact]
+    public async Task PrivateStoryChapters_AsStranger_ReturnsUnauthorized()
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync($"/api/stories/{PrivateStoryId}/chapters");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PrivateStoryChapters_AsAnonymous_ReturnsUnauthorized()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/stories/{PrivateStoryId}/chapters");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SharedStoryChapters_AsAnonymous_ReturnsUnauthorized()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/stories/{SharedStoryId}/chapters");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PublicStoryChapters_AsAnonymous_ReturnsChapters()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/stories/{PublicStoryId}/chapters");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<StoryChapterListModel>>();
+        Assert.Single(models);
+        Assert.Equal(PublicChapterId, models[0].Id);
+    }
+}

--- a/src/Recollections.Api.Tests/Sharing/StoryVisibilityAccessTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/StoryVisibilityAccessTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using Neptuo.Recollections.Entries;
+using Neptuo.Recollections.Sharing;
+using Neptuo.Recollections.Tests.Infrastructure;
+using Xunit;
+
+namespace Neptuo.Recollections.Tests.Sharing;
+
+/// <summary>
+/// Covers the anonymous / stranger / public-reader visibility dimensions for
+/// story-rooted read endpoints that the existing suite only exercises as an
+/// authenticated connected reader: timeline, chapter timeline, map, images, media.
+/// </summary>
+public class StoryVisibilityAccessTests : IClassFixture<ApiFactory>, IAsyncLifetime
+{
+    private readonly ApiFactory factory;
+
+    private const string OwnerUserId = "svi-owner-id";
+    private const string OwnerUserName = "sviowner";
+    private const string StrangerUserId = "svi-stranger-id";
+    private const string StrangerUserName = "svistranger";
+
+    private const string PrivateStoryId = "svi-story-private";
+    private const string PrivateChapterId = "svi-chapter-private";
+    private const string PublicStoryId = "svi-story-public";
+    private const string PublicChapterId = "svi-chapter-public";
+
+    public StoryVisibilityAccessTests(ApiFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await factory.SeedAsync(nameof(StoryVisibilityAccessTests), async (accountsDb, entriesDb) =>
+        {
+            await DatabaseSeeder.SeedUser(accountsDb, OwnerUserId, OwnerUserName);
+            await DatabaseSeeder.SeedUser(accountsDb, StrangerUserId, StrangerUserName);
+
+            var privateStory = await DatabaseSeeder.SeedStory(entriesDb, PrivateStoryId, OwnerUserId, isSharingInherited: false);
+            var privateChapter = await DatabaseSeeder.SeedChapter(entriesDb, PrivateChapterId, privateStory);
+
+            var publicStory = await DatabaseSeeder.SeedStory(entriesDb, PublicStoryId, OwnerUserId, isSharingInherited: false);
+            await DatabaseSeeder.SeedStoryShare(entriesDb, PublicStoryId, ShareStatusService.PublicUserId, Permission.Read);
+            var publicChapter = await DatabaseSeeder.SeedChapter(entriesDb, PublicChapterId, publicStory);
+
+            // An entry in the public story that is itself public — should be visible anonymously.
+            var publicEntry = await DatabaseSeeder.SeedEntry(
+                entriesDb,
+                "svi-entry-public",
+                OwnerUserId,
+                isSharingInherited: false,
+                story: publicStory,
+                when: new DateTime(2024, 9, 1, 10, 0, 0, DateTimeKind.Utc));
+            await DatabaseSeeder.SeedEntryShare(entriesDb, "svi-entry-public", ShareStatusService.PublicUserId, Permission.Read);
+            await DatabaseSeeder.SeedEntryLocation(entriesDb, publicEntry, 50.0, 14.0);
+            await DatabaseSeeder.SeedImage(entriesDb, "svi-image-public", publicEntry);
+
+            // A public entry in the public chapter
+            var publicChapterEntry = await DatabaseSeeder.SeedEntry(
+                entriesDb,
+                "svi-entry-public-chapter",
+                OwnerUserId,
+                isSharingInherited: false,
+                chapter: publicChapter,
+                when: new DateTime(2024, 9, 2, 10, 0, 0, DateTimeKind.Utc));
+            await DatabaseSeeder.SeedEntryShare(entriesDb, "svi-entry-public-chapter", ShareStatusService.PublicUserId, Permission.Read);
+
+            // A private entry in the public story (own visibility, not inheriting) — no shares.
+            await DatabaseSeeder.SeedEntry(
+                entriesDb,
+                "svi-entry-private-inherited",
+                OwnerUserId,
+                isSharingInherited: false,
+                story: publicStory,
+                when: new DateTime(2024, 9, 3, 10, 0, 0, DateTimeKind.Utc));
+        });
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    public static IEnumerable<object[]> PrivateStoryRoutes()
+    {
+        yield return new object[] { $"/api/stories/{PrivateStoryId}/timeline" };
+        yield return new object[] { $"/api/stories/{PrivateStoryId}/chapters/{PrivateChapterId}/timeline" };
+        yield return new object[] { $"/api/stories/{PrivateStoryId}/map" };
+        yield return new object[] { $"/api/stories/{PrivateStoryId}/images" };
+        yield return new object[] { $"/api/stories/{PrivateStoryId}/media" };
+    }
+
+    public static IEnumerable<object[]> PublicStoryRoutes()
+    {
+        yield return new object[] { $"/api/stories/{PublicStoryId}/timeline" };
+        yield return new object[] { $"/api/stories/{PublicStoryId}/chapters/{PublicChapterId}/timeline" };
+        yield return new object[] { $"/api/stories/{PublicStoryId}/map" };
+        yield return new object[] { $"/api/stories/{PublicStoryId}/images" };
+        yield return new object[] { $"/api/stories/{PublicStoryId}/media" };
+    }
+
+    [Theory, MemberData(nameof(PrivateStoryRoutes))]
+    public async Task PrivateStory_AsStranger_ReturnsUnauthorized(string route)
+    {
+        var client = factory.CreateClientForUser(StrangerUserId, StrangerUserName);
+        var response = await client.GetAsync(route);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory, MemberData(nameof(PrivateStoryRoutes))]
+    public async Task PrivateStory_AsAnonymous_ReturnsUnauthorized(string route)
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync(route);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory, MemberData(nameof(PublicStoryRoutes))]
+    public async Task PublicStory_AsAnonymous_ReturnsOk(string route)
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync(route);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PublicStory_Timeline_AsAnonymous_FiltersOutInheritedEntries()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/stories/{PublicStoryId}/timeline");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var page = await response.ReadJsonAsync<PageableList<EntryListModel>>();
+        var entryIds = page.Models.Select(e => e.Id).ToList();
+
+        Assert.Contains("svi-entry-public", entryIds);
+        Assert.DoesNotContain("svi-entry-private-inherited", entryIds);
+        Assert.DoesNotContain("svi-entry-public-chapter", entryIds); // chapter entries aren't in story timeline
+    }
+
+    [Fact]
+    public async Task PublicStory_Images_AsAnonymous_ReturnsOnlyPublicImages()
+    {
+        var client = factory.CreateAnonymousClient();
+        var response = await client.GetAsync($"/api/stories/{PublicStoryId}/images");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var models = await response.ReadJsonAsync<List<EntryImagesModel>>();
+        var entryIds = models.Select(m => m.EntryId).ToList();
+
+        Assert.Contains("svi-entry-public", entryIds);
+        Assert.DoesNotContain("svi-entry-private-inherited", entryIds);
+    }
+}

--- a/src/Recollections.Api.Tests/Sharing/StoryVisibilityAccessTests.cs
+++ b/src/Recollections.Api.Tests/Sharing/StoryVisibilityAccessTests.cs
@@ -66,10 +66,10 @@ public class StoryVisibilityAccessTests : IClassFixture<ApiFactory>, IAsyncLifet
                 when: new DateTime(2024, 9, 2, 10, 0, 0, DateTimeKind.Utc));
             await DatabaseSeeder.SeedEntryShare(entriesDb, "svi-entry-public-chapter", ShareStatusService.PublicUserId, Permission.Read);
 
-            // A private entry in the public story (own visibility, not inheriting) — no shares.
+            // A private, non-shared entry in the public story — should NOT be visible anonymously.
             await DatabaseSeeder.SeedEntry(
                 entriesDb,
-                "svi-entry-private-inherited",
+                "svi-entry-private",
                 OwnerUserId,
                 isSharingInherited: false,
                 story: publicStory,
@@ -122,7 +122,7 @@ public class StoryVisibilityAccessTests : IClassFixture<ApiFactory>, IAsyncLifet
     }
 
     [Fact]
-    public async Task PublicStory_Timeline_AsAnonymous_FiltersOutInheritedEntries()
+    public async Task PublicStory_Timeline_AsAnonymous_FiltersOutPrivateAndChapterEntries()
     {
         var client = factory.CreateAnonymousClient();
         var response = await client.GetAsync($"/api/stories/{PublicStoryId}/timeline");
@@ -132,7 +132,7 @@ public class StoryVisibilityAccessTests : IClassFixture<ApiFactory>, IAsyncLifet
         var entryIds = page.Models.Select(e => e.Id).ToList();
 
         Assert.Contains("svi-entry-public", entryIds);
-        Assert.DoesNotContain("svi-entry-private-inherited", entryIds);
+        Assert.DoesNotContain("svi-entry-private", entryIds);
         Assert.DoesNotContain("svi-entry-public-chapter", entryIds); // chapter entries aren't in story timeline
     }
 
@@ -147,6 +147,6 @@ public class StoryVisibilityAccessTests : IClassFixture<ApiFactory>, IAsyncLifet
         var entryIds = models.Select(m => m.EntryId).ToList();
 
         Assert.Contains("svi-entry-public", entryIds);
-        Assert.DoesNotContain("svi-entry-private-inherited", entryIds);
+        Assert.DoesNotContain("svi-entry-private", entryIds);
     }
 }


### PR DESCRIPTION
Closes #466.

## Why

Issue #466 tracked a large set of sharing-aware read endpoints that only had happy-path integration tests as authenticated connected readers. The anonymous, stranger, and public-reader visibility dimensions were untested, and regressions in the share-status code path could have silently leaked or hidden content. This PR fills in that grid.

## What

New xUnit integration tests under `src/Recollections.Api.Tests/Sharing/`, reusing the existing `ApiFactory` + `DatabaseSeeder` infrastructure:

- **Entry-nested:** `/story`, `/beings`, `/media`, `/images`, `/images/{id}` (+ `preview`/`thumbnail`/`original`), `/videos/{id}` (+ file routes).
- **Story-rooted:** `/chapters`, `/timeline`, `/chapters/{chapterId}/timeline`, `/map`, `/images`, `/media`.
- **Being-rooted:** `/timeline`, `/stories`, `/map`.
- **Profile:** `/api/profiles/{id}` and `/timeline/list`.

Each surface is exercised with the relevant actors (owner, stranger, anonymous, public share, connected reader) depending on what the endpoint supports. For file-content endpoints (image/video preview/thumbnail/original) there are no real files in the test environment, so tests assert `401` for unauthorized callers and `404` for authorized callers, which cleanly proves the authorization gate.

Added a small `DatabaseSeeder.SeedVideo` helper mirroring `SeedImage` to back the video-detail tests.

## Production fix included

While writing the anonymous-actor tests I hit a real bug: `DbConnectionProvider.GetConnectedUsersForAsync(string userId)` passed a `null` userId straight into `Dictionary.TryGetValue`, throwing `ArgumentNullException`. This happened any time an anonymous visitor hit a publicly-shared story timeline, being timeline, profile timeline, or map.

Fixed by short-circuiting on null/whitespace and returning an empty `ConnectedUsersModel`, which matches the "no active connections" semantics already used for unknown users. No behavior change for authenticated callers.

## Verification

`dotnet test src/Recollections.Api.Tests/Recollections.Api.Tests.csproj` — 210/210 pass (up from 154 before this PR).