### PR TITLE
Document migration rules for SQLite + Azure SQL compatibility

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,7 +20,7 @@
 
 ## Database Migrations
 
-EF Core migrations run against both **SQLite** (local dev) and **Azure SQL Server** (prod). Migrations are typically scaffolded via the SQLite provider, so you MUST manually review and adjust them so they work correctly on SQL Server as well. See issues #494 and #498 for past breakage.
+EF Core migrations run against both **SQLite** (local dev) and **Azure SQL Server** (prod). Migrations are typically scaffolded via the SQLite provider, so you MUST manually review and adjust them so they work correctly on SQL Server as well. See PRs #494 and #498 for past breakage.
 
 When adding or reviewing a migration, verify ALL of the following:
 
@@ -29,6 +29,6 @@ When adding or reviewing a migration, verify ALL of the following:
 - **String foreign key columns** must declare a `maxLength` that matches the referenced column (e.g. `maxLength: 36` for FKs to `AspNetUsers.Id`). A mismatched or missing length causes SQL Server to reject the FK due to incompatible types (`nvarchar(max)` vs `nvarchar(36)`).
 - **Indexed string columns** must declare a `maxLength`. SQL Server cannot build an index key over `nvarchar(max)`.
 - **No hardcoded SQLite-specific column types** (e.g. `type: "TEXT"`, `type: "INTEGER"`). Let EF map the CLR type so each provider picks the correct native type.
-- **Provider-specific fix-up migrations** (e.g. repairing past mistakes on SQL Server only) must guard with `migrationBuilder.ActiveProvider` and clearly document in an XML comment why the migration exists and why `Down` is a no-op (if applicable).
+- **Provider-specific fix-up migrations** (e.g. repairing past mistakes on SQL Server only) must guard with `migrationBuilder.ActiveProvider` and clearly document in an XML comment why the migration exists and why `Down` is a no-op, throws, or is otherwise intentionally limited (if applicable).
 
 Before committing a migration, re-read the generated `*.cs` file top-to-bottom with this checklist in mind — do not rely on the scaffolder's output alone.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,3 +17,18 @@
 ## Pull Request Reviews
 
 - Always reply to review comments when applying feedback on a PR.
+
+## Database Migrations
+
+EF Core migrations run against both **SQLite** (local dev) and **Azure SQL Server** (prod). Migrations are typically scaffolded via the SQLite provider, so you MUST manually review and adjust them so they work correctly on SQL Server as well. See issues #494 and #498 for past breakage.
+
+When adding or reviewing a migration, verify ALL of the following:
+
+- **Inherit from `MigrationWithSchema<DataContext>`**, never from `Migration` directly. Every `CreateTable`, `DropTable`, `CreateIndex`, `AddColumn`, `AddForeignKey`, etc. must pass `schema: Schema.Name`. Check existing migrations under `src/Recollections.*.Data/Migrations/` for reference.
+- **Integer identity (`Id`) columns** must carry `.Annotation("SqlServer:Identity", "1, 1")` in addition to the scaffolded `Sqlite:Autoincrement` annotation. Without it, SQL Server creates the column as plain `int NOT NULL` and inserts fail with "Cannot insert the value NULL into column 'Id'".
+- **String foreign key columns** must declare a `maxLength` that matches the referenced column (e.g. `maxLength: 36` for FKs to `AspNetUsers.Id`). A mismatched or missing length causes SQL Server to reject the FK due to incompatible types (`nvarchar(max)` vs `nvarchar(36)`).
+- **Indexed string columns** must declare a `maxLength`. SQL Server cannot build an index key over `nvarchar(max)`.
+- **No hardcoded SQLite-specific column types** (e.g. `type: "TEXT"`, `type: "INTEGER"`). Let EF map the CLR type so each provider picks the correct native type.
+- **Provider-specific fix-up migrations** (e.g. repairing past mistakes on SQL Server only) must guard with `migrationBuilder.ActiveProvider` and clearly document in an XML comment why the migration exists and why `Down` is a no-op (if applicable).
+
+Before committing a migration, re-read the generated `*.cs` file top-to-bottom with this checklist in mind — do not rely on the scaffolder's output alone.


### PR DESCRIPTION
Recent migrations broke production twice (#494, #498) because they were scaffolded against SQLite and silently produced schemas that SQL Server rejects or misinterprets. Nothing in the repo guidance reminded contributors (or Copilot) to adjust the generated files, so the same mistakes kept slipping through.

This PR adds a **Database Migrations** section to `.github/copilot-instructions.md` codifying the rules we learned the hard way:

- Inherit from `MigrationWithSchema<DataContext>` (never `Migration`) and always pass `schema: Schema.Name` on every table/index/column operation.
- Int identity (`Id`) columns need `.Annotation("SqlServer:Identity", "1, 1")` in addition to the scaffolded `Sqlite:Autoincrement`, otherwise SQL Server creates them as plain `int NOT NULL` and inserts fail (#498).
- String FK columns must declare a `maxLength` matching the referenced column (e.g. `36` for FKs to `AspNetUsers.Id`) so SQL Server accepts the relationship (#494).
- Indexed string columns must declare a `maxLength` — SQL Server cannot index `nvarchar(max)`.
- No hardcoded SQLite-only column types (`TEXT`, `INTEGER`); let EF pick the provider-native type.
- Provider-specific fix-up migrations must guard with `migrationBuilder.ActiveProvider` and document why `Down` behaves as it does.

Docs-only change; no code paths touched.