### PR TITLE
Add release notes for v0.20.0

### DIFF
--- a/src/Recollections.Blazor.UI/wwwroot/release-notes.json
+++ b/src/Recollections.Blazor.UI/wwwroot/release-notes.json
@@ -1,5 +1,19 @@
 [
     {
+        "version": "0.20.0",
+        "milestone": 52,
+        "breakingChanges": [],
+        "newFeatures": [
+            "\"On this day\" push notifications for anniversaries of your own and shared entries",
+            "Update screen now highlights what's new since your last seen version",
+            "Videos and images stream in as they download instead of waiting for the full file"
+        ],
+        "bugFixes": [
+            "Faster timeline loading for large stories",
+            "Country map view is now a session toggle instead of a saved preference"
+        ]
+    },
+    {
         "version": "0.19.0",
         "milestone": 50,
         "breakingChanges": [],


### PR DESCRIPTION
Prepends the v0.20.0 entry (milestone #52) to `release-notes.json` so the About page and PWA update screen show what shipped in this release.

### New features
- "On this day" push notifications for anniversaries of your own and shared entries (#506)
- Update screen now highlights what's new since your last seen version (#505)
- Videos and images stream in as they download instead of waiting for the full file (#491)

### Bug fixes
- Faster timeline loading for large stories (#504)
- Country map view is now a session toggle instead of a saved preference (#503)

Internal-only items in the milestone (EF migration fixes, tool refactors, macOS dev support, test coverage) were intentionally excluded per the release-notes style.