### PR TITLE
Bump GitHub Pages actions to Node 24 versions

### DIFF
--- a/.github/workflows/client-deploy.yml
+++ b/.github/workflows/client-deploy.yml
@@ -39,13 +39,13 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
The Client Deploy workflow has been emitting a deprecation warning that the Pages-related actions still run on Node.js 20, which will be forced to Node 24 in June 2026 and removed in September 2026.

Bumps the three actions used by `.github/workflows/client-deploy.yml` to the latest majors that ship with a Node 24 runtime:

- `actions/configure-pages@v5` -> `@v6`
- `actions/upload-pages-artifact@v3` -> `@v5` (this is the one transitively pulling in the flagged `upload-artifact@v4`)
- `actions/deploy-pages@v4` -> `@v5`

No behavior changes expected; all three are drop-in replacements for the usage in this workflow. Other workflows only use `actions/checkout@v4` and `actions/setup-dotnet@v4`, which are already current and unaffected by the warning.