### PR TITLE
Make PWA Store-ready and eliminate install-launch flash

### DIFF
--- a/src/Recollections.Blazor.UI/wwwroot/index.html
+++ b/src/Recollections.Blazor.UI/wwwroot/index.html
@@ -18,14 +18,15 @@
     <link rel="icon" href="/img/icon-192x192.png" type="image/png" />
     <link rel="apple-touch-icon" href="/img/icon-maskable-192x192.png" />
 
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
-    <link href="css/site.css" rel="stylesheet" />
-
     <style>
         /* Splash continuation: match the installed-app manifest splash (#fa8072)
-           so the OS splash -> first HTML paint hand-off is invisible. The overlay
-           is removed as soon as Blazor replaces <app>'s contents. */
-        html { background: #fa8072; }
+           so the OS splash -> first HTML paint hand-off is invisible. Declared
+           before the external stylesheets so the very first paint is salmon;
+           site.css's `body { background: var(--bs-body-bg) }` rule is intentionally
+           left to win the cascade for `body` once the app loads, while the inline
+           `html` background persists and the #app-splash overlay covers everything
+           until Blazor mounts. */
+        html, body { background: #fa8072; }
         body { margin: 0; }
         #app-splash {
             position: fixed;
@@ -38,6 +39,9 @@
         }
         #app-splash .loading-bar div { background: #fff; }
     </style>
+
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
+    <link href="css/site.css" rel="stylesheet" />
 </head>
 <body>
     <app>

--- a/src/Recollections.Blazor.UI/wwwroot/index.html
+++ b/src/Recollections.Blazor.UI/wwwroot/index.html
@@ -20,10 +20,28 @@
 
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
     <link href="css/site.css" rel="stylesheet" />
+
+    <style>
+        /* Splash continuation: match the installed-app manifest splash (#fa8072)
+           so the OS splash -> first HTML paint hand-off is invisible. The overlay
+           is removed as soon as Blazor replaces <app>'s contents. */
+        html { background: #fa8072; }
+        body { margin: 0; }
+        #app-splash {
+            position: fixed;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #fa8072;
+            z-index: 9999;
+        }
+        #app-splash .loading-bar div { background: #fff; }
+    </style>
 </head>
 <body>
     <app>
-        <div class="d-flex justify-content-center">
+        <div id="app-splash">
             <div class="loading-bar">
                 <div></div>
                 <div></div>

--- a/src/Recollections.Blazor.UI/wwwroot/manifest.json
+++ b/src/Recollections.Blazor.UI/wwwroot/manifest.json
@@ -1,8 +1,18 @@
 {
+  "id": "recollections-app",
   "short_name": "Recollections",
   "name": "Recollections by Neptuo",
+  "description": "Capture your memories as a timeline of entries with photos, locations and notes.",
   "start_url": "/",
+  "scope": "/",
+  "lang": "en",
+  "dir": "ltr",
   "display": "standalone",
+  "display_override": ["window-controls-overlay", "standalone"],
+  "orientation": "any",
+  "background_color": "#212529",
+  "theme_color": "#212529",
+  "categories": ["travel", "lifestyle", "photo"],
   "icons": [
     {
       "src":"/img/icon-192x192.png",

--- a/src/Recollections.Blazor.UI/wwwroot/manifest.json
+++ b/src/Recollections.Blazor.UI/wwwroot/manifest.json
@@ -1,5 +1,5 @@
 {
-  "id": "recollections-app",
+  "id": "/",
   "short_name": "Recollections",
   "name": "Recollections by Neptuo",
   "description": "Capture your memories as a timeline of entries with photos, locations and notes.",

--- a/src/Recollections.Blazor.UI/wwwroot/manifest.json
+++ b/src/Recollections.Blazor.UI/wwwroot/manifest.json
@@ -10,7 +10,7 @@
   "display": "standalone",
   "display_override": ["window-controls-overlay", "standalone"],
   "orientation": "any",
-  "background_color": "#212529",
+  "background_color": "#fa8072",
   "theme_color": "#212529",
   "categories": ["travel", "lifestyle", "photo"],
   "icons": [


### PR DESCRIPTION
Groundwork for #113 — publishing Recollections to the Microsoft Store (and, with the same manifest, Google Play via PWABuilder / TWA). PWABuilder inspects `manifest.json` and flags/blocks Windows packages when Store-relevant fields are missing, so the manifest needs to be "Store-ready" before we can generate an MSIX. While touching this, we also polish the install-launch experience so the OS manifest splash transitions seamlessly into the app.

## Manifest: Store-ready fields

Added to `src/Recollections.Blazor.UI/wwwroot/manifest.json`:

- `id` = `/` — explicit app identity (see note below)
- `scope` = `/`, `lang` = `en`, `dir` = `ltr`
- `description` — shown in install prompts and Store listing
- `orientation` = `any`
- `background_color` = `#fa8072` (salmon, matches the app icon and `$accent-color` in `_colors.scss`)
- `theme_color` = `#212529` (matches the existing `<meta name="theme-color">` and the app's dark top navbar)
- `categories` = `["travel", "lifestyle", "photo"]` (journaling covered by `lifestyle`, the closest W3C-registered category)
- `display_override` = `["window-controls-overlay", "standalone"]`

Existing `icons`, `screenshots`, `share_target`, `launch_handler`, `short_name`, `name`, `start_url`, and `display` are unchanged.

### Note on `id`

The processed manifest `id` is a URL resolved against the manifest origin. With no `id` today, browsers fall back to the processed `start_url`, so existing installs are keyed on `https://recollections.app/`.

Using `id: "/"` resolves to exactly the same URL, keeping existing browser installs matched to the new manifest. A non-path value like `"recollections-app"` would have resolved to `https://recollections.app/recollections-app` and silently orphaned every existing install. That's why `"/"` was chosen.

## Splash continuation (no more flash)

Before this PR, a cold launch of the installed PWA went: OS splash (salmon + icon) -> white page with small salmon loading bars -> app. That jump is ugly.

Fixed by making the first HTML paint match the manifest splash:

- Inline `html { background: #fa8072 }` in `<head>` *before* the external `site.css` link, so the very first paint is salmon (no white flash between OS splash and page).
- Pre-Blazor loader wrapped in a full-screen `#app-splash` overlay with the same salmon background, vertically and horizontally centered.
- Loading bars recolored white, scoped to `#app-splash` so every other in-app use of `.loading-bar` keeps its original salmon-on-white styling.

Overlay disappears automatically when Blazor mounts and replaces `<app>`'s contents — no JS hook needed.

## Out of scope

Running PWABuilder against the deployed site and uploading the generated MSIX / AAB to Microsoft Partner Center / Google Play — those are manual, one-off actions that happen after this deploys.

## Validation

- Manifest parses as valid JSON.
- `dotnet build src/Recollections.Blazor.UI` succeeds with 0 warnings / 0 errors.
