### PR TITLE
Preserve current page when sharing files to the app

### DIFF
--- a/src/Recollections.Blazor.UI/wwwroot/share-target.js
+++ b/src/Recollections.Blazor.UI/wwwroot/share-target.js
@@ -6,9 +6,9 @@ function shareTargetHandler(event) {
             const files = formData.getAll("allfiles");
             await storeFiles(files, null, null, null, null);
 
-            const allClients = await clients.matchAll();
-            if (allClients && allClients.length > 0) {
-                return Response.redirect(allClients[0].url, 303);
+            const existingClient = await findExistingClient(event);
+            if (existingClient) {
+                return Response.redirect(existingClient.url, 303);
             } else {
                 return Response.redirect('/', 303);
             }
@@ -16,6 +16,20 @@ function shareTargetHandler(event) {
     }
 
     return null;
+}
+
+// Picks the window the user is currently looking at so the share target
+// handler can redirect back to it instead of always landing on the timeline.
+// The client that is being navigated for this POST is excluded because its
+// URL already points at the share target action ("/").
+async function findExistingClient(event) {
+    const excludeId = event.resultingClientId;
+    const allClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    const candidates = allClients.filter(c => c.id && c.id !== excludeId);
+    return candidates.find(c => c.focused)
+        || candidates.find(c => c.visibilityState === 'visible')
+        || candidates[0]
+        || null;
 }
 
 // Sync with FileUpload.js (1:1)


### PR DESCRIPTION
Sharing files into the PWA via `share_target` always landed the user on the timeline, even when the app was already open on another page (entry detail, being, story, etc.). That is disruptive when the user is trying to attach photos to the entry they are currently looking at.

## Approach

The share target handler in `share-target.js` already tries to redirect back to an existing client's URL after storing the shared files, but it used `clients.matchAll()[0]`. Because the POST share action is `/`, one of the matched clients is the window being navigated for this share, whose URL is (or is becoming) `/` - so the redirect effectively sent the user to the timeline.

The handler now picks the existing client more carefully:

- Uses `clients.matchAll({ type: 'window', includeUncontrolled: true })`.
- Excludes `event.resultingClientId`, which is the client the browser is navigating for this POST.
- Prefers `focused`, then `visibilityState === 'visible'`, then any remaining candidate.

If no other window is open, behavior is unchanged and the user still lands on `/`. The unassigned-files notification already surfaces shared files on whichever page is shown, so keeping the current page is enough - no further client-side changes are needed.