### PR TITLE
Update Aspire AppHost SDK to 13.2.3

### DIFF
--- a/src/AppHost.cs
+++ b/src/AppHost.cs
@@ -1,4 +1,4 @@
-#:sdk Aspire.AppHost.Sdk@13.2.2
+#:sdk Aspire.AppHost.Sdk@13.2.3
 #:project .\Recollections.Api\Recollections.Api.csproj
 #:project .\Recollections.Blazor.UI\Recollections.Blazor.UI.csproj
 


### PR DESCRIPTION
Keeps the Aspire AppHost SDK on the latest patch so we pick up upstream fixes without lagging behind.

Bumps `Aspire.AppHost.Sdk` from 13.2.2 to 13.2.3 in `src/AppHost.cs`. This is the only Aspire reference in the repo. Verified via `dotnet restore ./src/AppHost.cs`.