### PR TITLE
Simplify VideoSizeBackfill to top-level statements with named args

### DIFF
--- a/tools/VideoSizeBackfill.cs
+++ b/tools/VideoSizeBackfill.cs
@@ -13,112 +13,110 @@ using Neptuo.Recollections.Entries;
 using Neptuo.Recollections.Migrations;
 using EntriesDataContext = Neptuo.Recollections.Entries.DataContext;
 
-await new VideoSizeBackfill().RunAsync(args);
-
-internal sealed class VideoSizeBackfill
+if (args.Length != 3)
 {
-    public async Task RunAsync(string[] args)
+    Console.WriteLine("Pass first argument with connection string to database, second with file storage type (fs/azure), third a connection to azure storage or local path template (relative path not supported).");
+    return;
+}
+
+// To bypass command-line arguments, replace with hardcoded values:
+string connectionString = args[0];
+string storageType = args[1];
+string storagePath = args[2];
+
+Console.WriteLine("Creating context.");
+using var entries = new EntriesDataContext(
+    DbContextOptions<EntriesDataContext>(connectionString, "Entries"),
+    Schema<EntriesDataContext>("Entries"));
+
+IFileStorage fileStorage = CreateFileStorage(storageType, storagePath);
+if (fileStorage == null)
+    return;
+
+Console.WriteLine("Getting videos missing size.");
+var videos = await entries.Videos
+    .Include(v => v.Entry)
+    .Where(v => v.OriginalSize == null)
+    .ToListAsync();
+
+Console.WriteLine($"Found '{videos.Count}' videos.");
+foreach (var video in videos)
+{
+    using Stream content = await fileStorage.FindAsync(video.Entry, video, VideoType.Original);
+    if (content == null)
     {
-        if (args.Length != 3)
-        {
-            Console.WriteLine("Pass first argument with connection string to database, second with file storage type (fs/azure), third a connection to azure storage or local path template (relative path not supported).");
-            return;
-        }
+        Console.WriteLine($"Missing original file for '{video.Id}'.");
+        continue;
+    }
 
-        Console.WriteLine("Creating context.");
-        using var entries = new EntriesDataContext(
-            DbContextOptions<EntriesDataContext>(args[0], "Entries"),
-            Schema<EntriesDataContext>("Entries"));
+    long size = await GetLengthAsync(content);
+    video.OriginalSize = size;
+    Console.WriteLine($"Video '{video.Id}' updated to {size} bytes.");
+}
 
-        IFileStorage fileStorage = CreateFileStorage(args[1], args[2]);
-        if (fileStorage == null)
-            return;
+Console.WriteLine("Saving changes.");
+await entries.SaveChangesAsync();
+Console.WriteLine("Done.");
 
-        Console.WriteLine("Getting videos missing size.");
-        var videos = await entries.Videos
-            .Include(v => v.Entry)
-            .Where(v => v.OriginalSize == null)
-            .ToListAsync();
 
-        Console.WriteLine($"Found '{videos.Count}' videos.");
-        foreach (var video in videos)
-        {
-            using Stream content = await fileStorage.FindAsync(video.Entry, video, VideoType.Original);
-            if (content == null)
+static IFileStorage CreateFileStorage(string storageType, string connection)
+{
+    if (storageType == "fs")
+    {
+        return new SystemIoFileStorage(
+            path => path,
+            Options.Create(new SystemIoStorageOptions() { PathTemplate = connection }),
+            ImageFormatDefinition.Jpeg);
+    }
+
+    if (storageType == "azure")
+        return new AzureFileStorage(Options.Create(new AzureStorageOptions() { ConnectionString = connection }));
+
+    Console.WriteLine($"Not supported type of file storage '{storageType}'.");
+    return null;
+}
+
+static async Task<long> GetLengthAsync(Stream content)
+{
+    if (content.CanSeek)
+        return content.Length;
+
+    long result = 0;
+    byte[] buffer = new byte[81920];
+    int read;
+    while ((read = await content.ReadAsync(buffer, 0, buffer.Length)) > 0)
+        result += read;
+
+    return result;
+}
+
+static DbContextOptions<T> DbContextOptions<T>(string connectionString, string schema)
+    where T : DbContext
+{
+    if (connectionString.StartsWith("Filename", StringComparison.OrdinalIgnoreCase))
+    {
+        var builder = new DbContextOptionsBuilder<T>()
+            .UseSqlite(connectionString);
+
+        return builder.Options;
+    }
+    else
+    {
+        var builder = new DbContextOptionsBuilder<T>()
+            .UseSqlServer(connectionString, sql =>
             {
-                Console.WriteLine($"Missing original file for '{video.Id}'.");
-                continue;
-            }
+                if (!string.IsNullOrEmpty(schema))
+                    sql.MigrationsHistoryTable("__EFMigrationsHistory", schema);
+            });
 
-            long size = await GetLengthAsync(content);
-            video.OriginalSize = size;
-            Console.WriteLine($"Video '{video.Id}' updated to {size} bytes.");
-        }
-
-        Console.WriteLine("Saving changes.");
-        await entries.SaveChangesAsync();
-        Console.WriteLine("Done.");
+        return builder.Options;
     }
+}
 
-    private static IFileStorage CreateFileStorage(string storageType, string connection)
-    {
-        if (storageType == "fs")
-        {
-            return new SystemIoFileStorage(
-                path => path,
-                Options.Create(new SystemIoStorageOptions() { PathTemplate = connection }),
-                ImageFormatDefinition.Jpeg);
-        }
-
-        if (storageType == "azure")
-            return new AzureFileStorage(Options.Create(new AzureStorageOptions() { ConnectionString = connection }));
-
-        Console.WriteLine($"Not supported type of file storage '{storageType}'.");
-        return null;
-    }
-
-    private static async Task<long> GetLengthAsync(Stream content)
-    {
-        if (content.CanSeek)
-            return content.Length;
-
-        long result = 0;
-        byte[] buffer = new byte[81920];
-        int read;
-        while ((read = await content.ReadAsync(buffer, 0, buffer.Length)) > 0)
-            result += read;
-
-        return result;
-    }
-
-    private static DbContextOptions<T> DbContextOptions<T>(string connectionString, string schema)
-        where T : DbContext
-    {
-        if (connectionString.StartsWith("Filename", StringComparison.OrdinalIgnoreCase))
-        {
-            var builder = new DbContextOptionsBuilder<T>()
-                .UseSqlite(connectionString);
-
-            return builder.Options;
-        }
-        else
-        {
-            var builder = new DbContextOptionsBuilder<T>()
-                .UseSqlServer(connectionString, sql =>
-                {
-                    if (!string.IsNullOrEmpty(schema))
-                        sql.MigrationsHistoryTable("__EFMigrationsHistory", schema);
-                });
-
-            return builder.Options;
-        }
-    }
-
-    private static SchemaOptions<T> Schema<T>(string name)
-        where T : DbContext
-    {
-        var schema = new SchemaOptions<T>() { Name = name };
-        MigrationWithSchema.SetSchema(schema);
-        return schema;
-    }
+static SchemaOptions<T> Schema<T>(string name)
+    where T : DbContext
+{
+    var schema = new SchemaOptions<T>() { Name = name };
+    MigrationWithSchema.SetSchema(schema);
+    return schema;
 }

--- a/tools/VideoSizeBackfill.cs
+++ b/tools/VideoSizeBackfill.cs
@@ -29,7 +29,7 @@ using var entries = new EntriesDataContext(
     DbContextOptions<EntriesDataContext>(connectionString, "Entries"),
     Schema<EntriesDataContext>("Entries"));
 
-IFileStorage fileStorage = CreateFileStorage(storageType, storagePath);
+IFileStorage? fileStorage = CreateFileStorage(storageType, storagePath);
 if (fileStorage == null)
     return;
 
@@ -42,7 +42,7 @@ var videos = await entries.Videos
 Console.WriteLine($"Found '{videos.Count}' videos.");
 foreach (var video in videos)
 {
-    using Stream content = await fileStorage.FindAsync(video.Entry, video, VideoType.Original);
+    using Stream? content = await fileStorage.FindAsync(video.Entry, video, VideoType.Original);
     if (content == null)
     {
         Console.WriteLine($"Missing original file for '{video.Id}'.");
@@ -59,18 +59,18 @@ await entries.SaveChangesAsync();
 Console.WriteLine("Done.");
 
 
-static IFileStorage CreateFileStorage(string storageType, string connection)
+static IFileStorage? CreateFileStorage(string storageType, string storagePathOrConnectionString)
 {
     if (storageType == "fs")
     {
         return new SystemIoFileStorage(
             path => path,
-            Options.Create(new SystemIoStorageOptions() { PathTemplate = connection }),
+            Options.Create(new SystemIoStorageOptions() { PathTemplate = storagePathOrConnectionString }),
             ImageFormatDefinition.Jpeg);
     }
 
     if (storageType == "azure")
-        return new AzureFileStorage(Options.Create(new AzureStorageOptions() { ConnectionString = connection }));
+        return new AzureFileStorage(Options.Create(new AzureStorageOptions() { ConnectionString = storagePathOrConnectionString }));
 
     Console.WriteLine($"Not supported type of file storage '{storageType}'.");
     return null;


### PR DESCRIPTION
Refactors VideoSizeBackfill tool:
- Converts from class-based to top-level statements
- Extracts `args[]` indexing into named local variables (`connectionString`, `storageType`, `storagePath`) for easy switching between CLI `args` and hardcoded values
- Converts instance methods to static local functions