### PR TITLE
Fix Timeline component not reloading on parent parameter changes

### DIFF
--- a/src/Recollections.Blazor.UI/Accounts/Pages/Profile.razor
+++ b/src/Recollections.Blazor.UI/Accounts/Pages/Profile.razor
@@ -48,7 +48,7 @@
                 }
 
                 <div class="mt-4 timeline-narrow">
-                    <Timeline DataGetter="@((offset, count) => EntriesApi.GetTimelineListAsync(UserId, offset, count))" NoMoreText="Here the user started..." />
+                    <Timeline DataGetter="@((offset, count) => EntriesApi.GetTimelineListAsync(UserId, offset, count))" DataKey="@UserId" NoMoreText="Here the user started..." />
                 </div>
             </div>
         </PermissionContainer>

--- a/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor.cs
@@ -122,7 +122,7 @@ namespace Neptuo.Recollections.Entries.Components
                     galleryMediaByEntryId.Clear();
                     galleryMediaLoading.Clear();
                     currentGalleryEntryId = null;
-                    loadAsyncFromParametersSet = LoadAsync().ContinueWith(_ => InvokeAsync(() => { loadAsyncFromParametersSet = null; StateHasChanged(); }));
+                    loadAsyncFromParametersSet = LoadAsync().ContinueWith(_ => { loadAsyncFromParametersSet = null; StateHasChanged(); });
                 }
             }
             else if (Entries.Count == 0)
@@ -131,7 +131,7 @@ namespace Neptuo.Recollections.Entries.Components
                 if (loadAsyncFromParametersSet == null)
                 {
                     Log.Debug("LoadAsync");
-                    loadAsyncFromParametersSet = LoadAsync().ContinueWith(_ => InvokeAsync(() => { loadAsyncFromParametersSet = null; StateHasChanged(); }));
+                    loadAsyncFromParametersSet = LoadAsync().ContinueWith(_ => { loadAsyncFromParametersSet = null; StateHasChanged(); });
                 }
                 else
                 {

--- a/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor.cs
@@ -109,11 +109,21 @@ namespace Neptuo.Recollections.Entries.Components
             else if (previousDataKey != DataKey && previousDataKey != null)
             {
                 previousDataKey = DataKey;
-                Log.Debug($"DataKey changed to '{DataKey}', reloading");
-                Entries.Clear();
-                offset = 0;
-                HasMore = false;
-                loadAsyncFromParametersSet = LoadAsync().ContinueWith(t => { loadAsyncFromParametersSet = null; StateHasChanged(); });
+                if (loadAsyncFromParametersSet != null)
+                {
+                    Log.Debug($"DataKey changed to '{DataKey}', but load already in progress, skipping");
+                }
+                else
+                {
+                    Log.Debug($"DataKey changed to '{DataKey}', reloading");
+                    Entries.Clear();
+                    offset = 0;
+                    HasMore = false;
+                    galleryMediaByEntryId.Clear();
+                    galleryMediaLoading.Clear();
+                    currentGalleryEntryId = null;
+                    loadAsyncFromParametersSet = LoadAsync().ContinueWith(_ => InvokeAsync(() => { loadAsyncFromParametersSet = null; StateHasChanged(); }));
+                }
             }
             else if (Entries.Count == 0)
             {
@@ -121,7 +131,7 @@ namespace Neptuo.Recollections.Entries.Components
                 if (loadAsyncFromParametersSet == null)
                 {
                     Log.Debug("LoadAsync");
-                    loadAsyncFromParametersSet = LoadAsync().ContinueWith(t => { loadAsyncFromParametersSet = null; StateHasChanged(); });
+                    loadAsyncFromParametersSet = LoadAsync().ContinueWith(_ => InvokeAsync(() => { loadAsyncFromParametersSet = null; StateHasChanged(); }));
                 }
                 else
                 {

--- a/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor.cs
@@ -50,6 +50,10 @@ namespace Neptuo.Recollections.Entries.Components
         [Parameter]
         public string CssClass { get; set; }
 
+        [Parameter]
+        public string DataKey { get; set; }
+
+        private string previousDataKey;
         private int offset;
         private Task loadAsyncFromParametersSet;
         private string scrollToEntryId;
@@ -102,8 +106,18 @@ namespace Neptuo.Recollections.Entries.Components
                 var position = FindPositionFromHistoryEntry();
                 QueuePositionRestore(position);
             }
+            else if (previousDataKey != DataKey && previousDataKey != null)
+            {
+                previousDataKey = DataKey;
+                Log.Debug($"DataKey changed to '{DataKey}', reloading");
+                Entries.Clear();
+                offset = 0;
+                HasMore = false;
+                loadAsyncFromParametersSet = LoadAsync().ContinueWith(t => { loadAsyncFromParametersSet = null; StateHasChanged(); });
+            }
             else if (Entries.Count == 0)
             {
+                previousDataKey = DataKey;
                 if (loadAsyncFromParametersSet == null)
                 {
                     Log.Debug("LoadAsync");
@@ -113,6 +127,10 @@ namespace Neptuo.Recollections.Entries.Components
                 {
                     Log.Debug("LoadAsync skipped due to pending load operation");
                 }
+            }
+            else
+            {
+                previousDataKey = DataKey;
             }
         }
 

--- a/src/Recollections.Blazor.UI/Entries/Pages/BeingDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/BeingDetail.razor
@@ -56,7 +56,7 @@
                 </div>
 
                 <div class="mb-3 timeline-narrow">
-                    <Timeline DataGetter="@((offset, count) => Api.GetBeingTimelineAsync(Model.Id, offset, count))" NoMoreText="@($"Here {Model.Name} started...")" />
+                    <Timeline DataGetter="@((offset, count) => Api.GetBeingTimelineAsync(Model.Id, offset, count))" DataKey="@BeingId" NoMoreText="@($"Here {Model.Name} started...")" />
                 </div>
             </div>
         </PermissionContainer>


### PR DESCRIPTION
When navigating between pages of the same type with different route parameters (e.g., from one being's detail to another), the embedded `Timeline` component kept showing stale data. The parent pages correctly detected parameter changes and reloaded their own data, but Timeline only loaded when `Entries.Count == 0` and had no way to know its `DataGetter` delegate now pointed to a different data source.

## Approach

Added a `DataKey` string parameter to the `Timeline` component. When `DataKey` changes between renders, the component clears its entries, resets offset, and reloads from the current `DataGetter`. Parent pages pass their route parameter as `DataKey`:

- `BeingDetail.razor` passes `DataKey="@BeingId"`
- `Profile.razor` passes `DataKey="@UserId"`

All other pages with route parameters (EntryDetail, StoryDetail, ImageDetail, VideoDetail, Calendar, Search) already correctly handle parameter changes via the `previousXxxId` pattern and don't embed a Timeline with a dynamic data source.

Fixes #288