### PR TITLE
Strip token query parameter from SW navigation requests

### DIFF
--- a/src/Recollections.Blazor.UI/wwwroot/service-worker.published.js
+++ b/src/Recollections.Blazor.UI/wwwroot/service-worker.published.js
@@ -122,16 +122,45 @@ async function onFetch(event) {
         return response;
     }
 
+    // Strip the auth token from navigation URLs before touching the cache or
+    // the network. The SPA still reads window.location.search after it boots,
+    // so the token remains available for the API auth exchange; this just
+    // keeps the SW's fetch/cache fallback from failing on a URL the server
+    // doesn't handle.
+    const fetchRequest = stripTokenFromNavigation(event.request);
+
     let cachedResponse = null;
-    if (event.request.method === 'GET') {
+    if (fetchRequest.method === 'GET') {
         // For all navigation requests, try to serve index.html from cache
         // If you need some URLs to be server-rendered, edit the following check to exclude those URLs
-        const shouldServeIndexHtml = event.request.mode === 'navigate';
+        const shouldServeIndexHtml = fetchRequest.mode === 'navigate';
 
-        const request = shouldServeIndexHtml ? 'index.html' : event.request;
+        const request = shouldServeIndexHtml ? 'index.html' : fetchRequest;
         const cache = await caches.open(cacheName);
         cachedResponse = await cache.match(request);
     }
 
-    return cachedResponse || fetch(event.request);
+    return cachedResponse || fetch(fetchRequest);
+}
+
+function stripTokenFromNavigation(request) {
+    if (request.mode !== 'navigate') {
+        return request;
+    }
+
+    const url = new URL(request.url);
+    if (!url.searchParams.has('token')) {
+        return request;
+    }
+
+    url.searchParams.delete('token');
+    return new Request(url.toString(), {
+        method: request.method,
+        headers: request.headers,
+        mode: request.mode,
+        credentials: request.credentials,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        integrity: request.integrity
+    });
 }

--- a/src/Recollections.Blazor.UI/wwwroot/service-worker.published.js
+++ b/src/Recollections.Blazor.UI/wwwroot/service-worker.published.js
@@ -148,6 +148,12 @@ function stripTokenFromNavigation(request) {
         return request;
     }
 
+    // Only rebuild GET navigations; non-GET (e.g. form POSTs) carry a body
+    // that wouldn't survive being copied into a new Request here.
+    if (request.method !== 'GET') {
+        return request;
+    }
+
     const url = new URL(request.url);
     if (!url.searchParams.has('token')) {
         return request;


### PR DESCRIPTION
Production reported a recurring service worker error when users land on the app via a token-bearing URL:

```
The FetchEvent for "https://recollections.app/?token=demo" resulted in a network error response: the promise was rejected.
```

## Why

`onFetch` in `service-worker.published.js` forwarded the raw navigation request (including `?token=...`) both to `cache.match` and to the `fetch()` network fallback. When the cache miss happened and the network fetch then failed for any reason, the promise returned to `respondWith()` rejected, surfacing the error above to users.

## What changed

Added `stripTokenFromNavigation()`, called from `onFetch` for `mode === 'navigate'` requests. It rebuilds the `Request` without the `token` query parameter before the cache lookup and the network fallback. Non-navigation requests are passed through untouched.

The SPA still reads `window.location.search` after boot (`UserState.OnInitializedAsync`), so the token remains available for the `LoginWithTokenAsync` API exchange. Only the SW-side fetch sees the cleaned URL.

## Notes

- Only the published service worker needed the change; the dev `service-worker.js` does not call `respondWith()` on regular fetches.
- No equivalent issue is filed; this is a follow-up to a production console report.