### PR TITLE
Reorganize bottom menu: move logout inline with user items

### DIFF
--- a/src/Recollections.Blazor.UI/Commons/Layouts/BottomMenu.razor
+++ b/src/Recollections.Blazor.UI/Commons/Layouts/BottomMenu.razor
@@ -48,17 +48,7 @@
                 <VersionInfo Separator="false" />
             </div>
         </TitleContent>
-        <HeaderContent>
-            @foreach (var item in Menu.User.Where(m => m.Text == "Logout"))
-            {
-                <button class="btn p-1 border-0 text-danger ms-auto" @onclick="@(() => { Offcanvas.Hide(); item.OnClick(); })">
-                    <Icon Identifier="@item.Icon" CssClass="@item.CssClass" />
-                    <span class="text d-inline text-truncate">
-                        @item.Text
-                    </span>
-                </button>
-            }
-        </HeaderContent>
+        <HeaderContent />
         <ChildContent>
             @if (Menu != null)
             {
@@ -68,7 +58,7 @@
                 </div>
                 <hr />
                 <div class="row g-1">
-                    @foreach (var item in Menu.User.Where(m => m.Text != "Logout"))
+                    @foreach (var item in Menu.User)
                         @MainMenuItem(item)
                 </div>
             }
@@ -81,8 +71,9 @@
     RenderFragment MainMenuItem(MenuItem item)
     {
         var isLogout = item.Text == "Logout";
+        var colClass = isLogout ? "col-3 ms-auto" : "col-3";
         return 
-            @<div class="col-3">
+            @<div class="@colClass">
                 @if (item.Url != null)
                 {
                     <Match Url="@item.Url" PageType="@item.PageType" Context="IsActive">
@@ -96,7 +87,7 @@
                 }
                 else
                 {
-                    <button class="btn p-1 border-0 w-100" @onclick="@(() => { Offcanvas.Hide(); item.OnClick(); })">
+                    <button class="btn p-1 border-0 w-100 @(isLogout ? "text-danger" : "")" @onclick="@(() => { Offcanvas.Hide(); item.OnClick(); })">
                         <Icon Identifier="@item.Icon" CssClass="@item.CssClass" />
                         <span class="text d-block text-truncate">
                             @item.Text

--- a/src/Recollections.Blazor.UI/Commons/Layouts/BottomMenu.razor
+++ b/src/Recollections.Blazor.UI/Commons/Layouts/BottomMenu.razor
@@ -77,7 +77,7 @@
                 @if (item.Url != null)
                 {
                     <Match Url="@item.Url" PageType="@item.PageType" Context="IsActive">
-                        <a href="@item.Url" class="btn p-1 border-0 @(IsActive ? "text-primary" : "") w-100">
+                        <a href="@item.Url" class="btn p-1 px-0 border-0 @(IsActive ? "text-primary" : "") w-100">
                             <Icon Identifier="@item.Icon" CssClass="@item.CssClass" />
                             <span class="text d-block text-truncate">
                                 @item.Text
@@ -87,7 +87,7 @@
                 }
                 else
                 {
-                    <button class="btn p-1 border-0 w-100 @(isLogout ? "text-danger" : "")" @onclick="@(() => { Offcanvas.Hide(); item.OnClick(); })">
+                    <button class="btn p-1 px-0 border-0 w-100 @(isLogout ? "text-danger" : "")" @onclick="@(() => { Offcanvas.Hide(); item.OnClick(); })">
                         <Icon Identifier="@item.Icon" CssClass="@item.CssClass" />
                         <span class="text d-block text-truncate">
                             @item.Text

--- a/src/Recollections.Blazor.UI/Commons/Layouts/HeadLayout.razor.cs
+++ b/src/Recollections.Blazor.UI/Commons/Layouts/HeadLayout.razor.cs
@@ -104,7 +104,7 @@ public class MenuList
         Add(new MenuItem("Profile", "address-card", OnClick: () => navigator.OpenProfile(userState.UserId)), User);
         Add(new MenuItem("Connections", "link", Url: navigator.UrlConnections()), User);
         Add(new MenuItem("Notifications", "bell", Url: navigator.UrlNotifications()), User);
-        Add(new MenuItem("Change password", "key", OnClick: changePassword), User);
+        Add(new MenuItem("Password", "key", OnClick: changePassword), User);
         Add(new MenuItem("Theme", "moon", OnClick: changeTheme), User);
         Add(new MenuItem("Logout", "sign-out-alt", OnClick: () => _ = userState.LogoutAsync()), User);
     }


### PR DESCRIPTION
Since user items in the bottom menu offcanvas now span two rows, the logout button no longer needs its own special placement in the offcanvas header. This PR moves it into the standard user items grid for a cleaner layout.

**Changes:**

- Moved the logout button from the offcanvas HeaderContent into the user items row, styled red (text-danger) and pushed right with ms-auto
- Renamed "Change password" menu item to "Password" for brevity in the grid
- Added px-0 to offcanvas item buttons/links to prevent horizontal padding overflow in tight columns

Fixes: #522