### PR TITLE
Show popup card for image/video markers on entry detail map

### DIFF
--- a/src/Recollections.Blazor.UI/Entries/Components/MediaCardPopover.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/MediaCardPopover.razor
@@ -35,10 +35,7 @@
         {
             <a href="@Navigator.UrlImageDetail(EntryId, Model.Image.Id)" class="text-decoration-none text-body">
                 <div class="card" style="max-width: 200px;">
-                    <div class="card-body p-0">
-                        <EntryMedia EntryId="@EntryId" Image="@Model.Image" Type="@MediaType.Thumbnail" />
-                    </div>
-                    <div class="card-footer p-2">
+                    <div class="card-body p-3">
                         <div class="information">
                             <Icon Identifier="image" />
                             @Model.Image.Name
@@ -55,10 +52,7 @@
         {
             <a href="@Navigator.UrlVideoDetail(EntryId, Model.Video.Id)" class="text-decoration-none text-body">
                 <div class="card" style="max-width: 200px;">
-                    <div class="card-body p-0">
-                        <EntryMedia EntryId="@EntryId" Video="@Model.Video" Type="@MediaType.Thumbnail" />
-                    </div>
-                    <div class="card-footer p-2">
+                    <div class="card-body p-3">
                         <div class="information">
                             <Icon Identifier="film" />
                             @Model.Video.Name

--- a/src/Recollections.Blazor.UI/Entries/Components/MediaCardPopover.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/MediaCardPopover.razor
@@ -4,9 +4,6 @@
     protected Navigator Navigator { get; set; }
 
     [Inject]
-    protected Entries.Api Api { get; set; }
-
-    [Inject]
     protected PopoverInterop Popover { get; set; }
 
     [Inject]
@@ -37,9 +34,9 @@
         @if (Model.Image != null)
         {
             <a href="@Navigator.UrlImageDetail(EntryId, Model.Image.Id)" class="text-decoration-none text-body">
-                <div class="card">
+                <div class="card" style="max-width: 200px;">
                     <div class="card-body p-0">
-                        <img src="@Api.GetMediaUrl(Model.Image.Thumbnail.Url)" class="card-img-top" alt="@Model.Image.Name" style="max-width: 200px;" />
+                        <EntryMedia EntryId="@EntryId" Image="@Model.Image" Type="@MediaType.Thumbnail" />
                     </div>
                     <div class="card-footer p-2">
                         <div class="information">
@@ -57,9 +54,9 @@
         else if (Model.Video != null)
         {
             <a href="@Navigator.UrlVideoDetail(EntryId, Model.Video.Id)" class="text-decoration-none text-body">
-                <div class="card">
+                <div class="card" style="max-width: 200px;">
                     <div class="card-body p-0">
-                        <img src="@Api.GetMediaUrl(Model.Video.Thumbnail.Url)" class="card-img-top" alt="@Model.Video.Name" style="max-width: 200px;" />
+                        <EntryMedia EntryId="@EntryId" Video="@Model.Video" Type="@MediaType.Thumbnail" />
                     </div>
                     <div class="card-footer p-2">
                         <div class="information">

--- a/src/Recollections.Blazor.UI/Entries/Components/MediaCardPopover.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/MediaCardPopover.razor
@@ -1,0 +1,78 @@
+@code
+{
+    [Inject]
+    protected Navigator Navigator { get; set; }
+
+    [Inject]
+    protected Entries.Api Api { get; set; }
+
+    [Inject]
+    protected PopoverInterop Popover { get; set; }
+
+    [Inject]
+    protected UiOptions UiOptions { get; set; }
+
+    [Parameter]
+    public string EntryId { get; set; }
+
+    [Parameter]
+    public MediaModel Model { get; set; }
+
+    public ElementReference ContentRef;
+
+    public async Task ShowAsync(ElementReference trigger)
+    {
+        await Popover.ShowFromElementAsync(trigger, ContentRef);
+    }
+
+    public async Task HideAsync()
+    {
+        await Popover.HideActiveAsync();
+    }
+}
+
+@if (Model != null)
+{
+    <div @ref="ContentRef" style="display:none">
+        @if (Model.Image != null)
+        {
+            <a href="@Navigator.UrlImageDetail(EntryId, Model.Image.Id)" class="text-decoration-none text-body">
+                <div class="card">
+                    <div class="card-body p-0">
+                        <img src="@Api.GetMediaUrl(Model.Image.Thumbnail.Url)" class="card-img-top" alt="@Model.Image.Name" style="max-width: 200px;" />
+                    </div>
+                    <div class="card-footer p-2">
+                        <div class="information">
+                            <Icon Identifier="image" />
+                            @Model.Image.Name
+                        </div>
+                        <div class="information">
+                            <Icon Identifier="calendar-alt" />
+                            @Model.Image.When.ToString(UiOptions.DateFormat)
+                        </div>
+                    </div>
+                </div>
+            </a>
+        }
+        else if (Model.Video != null)
+        {
+            <a href="@Navigator.UrlVideoDetail(EntryId, Model.Video.Id)" class="text-decoration-none text-body">
+                <div class="card">
+                    <div class="card-body p-0">
+                        <img src="@Api.GetMediaUrl(Model.Video.Thumbnail.Url)" class="card-img-top" alt="@Model.Video.Name" style="max-width: 200px;" />
+                    </div>
+                    <div class="card-footer p-2">
+                        <div class="information">
+                            <Icon Identifier="film" />
+                            @Model.Video.Name
+                        </div>
+                        <div class="information">
+                            <Icon Identifier="calendar-alt" />
+                            @Model.Video.When.ToString(UiOptions.DateFormat)
+                        </div>
+                    </div>
+                </div>
+            </a>
+        }
+    </div>
+}

--- a/src/Recollections.Blazor.UI/Entries/Components/MediaCardPopover.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/MediaCardPopover.razor
@@ -35,7 +35,10 @@
         {
             <a href="@Navigator.UrlImageDetail(EntryId, Model.Image.Id)" class="text-decoration-none text-body">
                 <div class="card" style="max-width: 200px;">
-                    <div class="card-body p-3">
+                    <div class="card-body p-0">
+                        <EntryMedia EntryId="@EntryId" Image="@Model.Image" Type="@MediaType.Thumbnail" />
+                    </div>
+                    <div class="card-footer p-2">
                         <div class="information">
                             <Icon Identifier="image" />
                             @Model.Image.Name
@@ -52,7 +55,10 @@
         {
             <a href="@Navigator.UrlVideoDetail(EntryId, Model.Video.Id)" class="text-decoration-none text-body">
                 <div class="card" style="max-width: 200px;">
-                    <div class="card-body p-3">
+                    <div class="card-body p-0">
+                        <EntryMedia EntryId="@EntryId" Video="@Model.Video" Type="@MediaType.Thumbnail" />
+                    </div>
+                    <div class="card-footer p-2">
                         <div class="information">
                             <Icon Identifier="film" />
                             @Model.Video.Name

--- a/src/Recollections.Blazor.UI/Entries/Components/MediaPopoverHandler.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/MediaPopoverHandler.cs
@@ -24,7 +24,7 @@ namespace Neptuo.Recollections.Entries.Components
             {
                 showPopoverPending = false;
 
-                if (SelectedMedia != null && selectedMarkerIndex >= 0 && map != null)
+                if (SelectedMedia != null && selectedMarkerIndex >= 0 && map != null && popover.ContentRef.Id != null)
                 {
                     await map.ShowMarkerPopoverAsync(selectedMarkerIndex, popover.ContentRef);
                 }

--- a/src/Recollections.Blazor.UI/Entries/Components/MediaPopoverHandler.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/MediaPopoverHandler.cs
@@ -1,0 +1,40 @@
+using Neptuo.Recollections.Components;
+using System.Threading.Tasks;
+
+namespace Neptuo.Recollections.Entries.Components
+{
+    public class MediaPopoverHandler
+    {
+        private int selectedMarkerIndex = -1;
+        private bool showPopoverPending;
+
+        public MediaModel SelectedMedia { get; private set; }
+
+        public async Task SelectAsync(int markerIndex, MediaModel media, MediaCardPopover popover)
+        {
+            await popover.HideAsync();
+            selectedMarkerIndex = markerIndex;
+            SelectedMedia = media;
+            showPopoverPending = true;
+        }
+
+        public async Task TryShowPopoverAsync(Map map, MediaCardPopover popover)
+        {
+            if (showPopoverPending)
+            {
+                showPopoverPending = false;
+
+                if (SelectedMedia != null && selectedMarkerIndex >= 0 && map != null)
+                {
+                    await map.ShowMarkerPopoverAsync(selectedMarkerIndex, popover.ContentRef);
+                }
+            }
+        }
+
+        public async ValueTask DisposeAsync(MediaCardPopover popover)
+        {
+            if (popover != null)
+                await popover.HideAsync();
+        }
+    }
+}

--- a/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor
+++ b/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor
@@ -82,7 +82,7 @@
                 {
                     <div class="gps">
                         <MapToggle DialogTitle="@($"{Model.Title}: Map")" Text="@MapTitle" IsPlaceHolder="@(!HasMapContent)" IsEnabled="@(HasMapContent || Permissions.IsEditable)">
-                            <Map Markers="@Markers" Path="@Model.Track?.Data" MarkersChanged="@(() => SaveLocationsAsync())" IsAdditive="true" MarkerSelected="OnLocationSelected" PathSelected="OnTrackSelected" />
+                            <Map @ref="mapComponent" Markers="@Markers" Path="@Model.Track?.Data" MarkersChanged="@(() => SaveLocationsAsync())" IsAdditive="true" MarkerSelected="OnLocationSelected" PathSelected="OnTrackSelected" />
                         </MapToggle>
                     </div>
                 }
@@ -151,3 +151,5 @@
     <StoryPicker @ref="StoryPicker" Selected="StorySelectedAsync" />
     <BeingPicker @ref="BeingPicker" Selected="BeingSelectedAsync" />
 </LoadingSection>
+
+<MediaCardPopover @ref="mediaPopover" EntryId="@EntryId" Model="MediaPopoverHandler.SelectedMedia" />

--- a/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 
 namespace Neptuo.Recollections.Entries.Pages
 {
-    public partial class EntryDetail : IDisposable
+    public partial class EntryDetail : IAsyncDisposable
     {
         [Inject]
         protected Api Api { get; set; }
@@ -57,6 +57,10 @@ namespace Neptuo.Recollections.Entries.Pages
         protected EntryStoryModel Story { get; set; }
         protected List<EntryBeingModel> Beings { get; } = new List<EntryBeingModel>();
         protected string BeingsTitle => Beings.Count > 0 ? String.Join(", ", Beings.Select(b => b.Name)) : null;
+        protected MediaPopoverHandler MediaPopoverHandler { get; } = new();
+        protected MediaCardPopover mediaPopover;
+        protected Map mapComponent;
+
         protected bool HasStory => Story != null && Story.StoryId != null;
         protected string StoryTitle
         {
@@ -117,10 +121,17 @@ namespace Neptuo.Recollections.Entries.Pages
             }
         }
         
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
             previousUploadListener?.Dispose();
             previousTrackUploadListener?.Dispose();
+            await MediaPopoverHandler.DisposeAsync(mediaPopover);
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+            await MediaPopoverHandler.TryShowPopoverAsync(mapComponent, mediaPopover);
         }
 
         private async Task LoadStoryAsync()
@@ -379,7 +390,7 @@ namespace Neptuo.Recollections.Entries.Pages
         protected LocationEdit LocationEdit { get; set; }
         protected TrackEdit TrackEdit { get; set; }
 
-        protected void OnLocationSelected(int index)
+        protected async Task OnLocationSelected(int index)
         {
             Log.Debug($"Marker selected '{index}'.");
 
@@ -387,19 +398,12 @@ namespace Neptuo.Recollections.Entries.Pages
             {
                 var media = Media[index];
                 if (media.Image != null)
-                {
-                    var image = media.Image;
-                    Log.Debug($"Selected image '{image.Id}'.");
-
-                    Navigator.OpenImageDetail(EntryId, image.Id);
-                }
+                    Log.Debug($"Selected image '{media.Image.Id}'.");
                 else if (media.Video != null)
-                {
-                    var video = media.Video;
-                    Log.Debug($"Selected video '{video.Id}'.");
+                    Log.Debug($"Selected video '{media.Video.Id}'.");
 
-                    Navigator.OpenVideoDetail(EntryId, video.Id);
-                }
+                await MediaPopoverHandler.SelectAsync(index, media, mediaPopover);
+                StateHasChanged();
             }
             else
             {

--- a/src/Recollections.Blazor.UI/wwwroot/css/site.css
+++ b/src/Recollections.Blazor.UI/wwwroot/css/site.css
@@ -26133,4 +26133,4 @@ video.pswp__video {
 .version {
   color: #aaaaaa;
 }
-/*# sourceMappingURL=/Users/marekfisera/.copilot/copilot-worktrees/Recollections/maraf-sturdy-happiness/src/Recollections.Blazor.UI/wwwroot/css/site.css.map */
+/*# sourceMappingURL=site.css.map */

--- a/src/Recollections.Blazor.UI/wwwroot/css/site.css
+++ b/src/Recollections.Blazor.UI/wwwroot/css/site.css
@@ -26133,4 +26133,4 @@ video.pswp__video {
 .version {
   color: #aaaaaa;
 }
-/*# sourceMappingURL=wwwroot/css/site.css.map */
+/*# sourceMappingURL=/Users/marekfisera/.copilot/copilot-worktrees/Recollections/maraf-sturdy-happiness/src/Recollections.Blazor.UI/wwwroot/css/site.css.map */

--- a/src/Recollections.Blazor.UI/wwwroot/js/site.js
+++ b/src/Recollections.Blazor.UI/wwwroot/js/site.js
@@ -140,8 +140,9 @@ window.Bootstrap = {
                 trigger.removeAttribute("title");
             }
 
-            // Remember original parent so we can move the node back on hide.
+            // Remember original position so we can restore the node exactly on hide.
             var originalParent = contentElement.parentNode;
+            var originalNextSibling = contentElement.nextSibling;
 
             // Show the content element (it starts hidden) and pass the live DOM node
             // so async updates (e.g. image loading via JS interop) are visible.
@@ -165,7 +166,7 @@ window.Bootstrap = {
                 }
             };
 
-            Bootstrap.Popover._active = { popover: popover, dismiss: dismissHandler, trigger: trigger, originalTitle: originalTitle, contentElement: contentElement, originalParent: originalParent };
+            Bootstrap.Popover._active = { popover: popover, dismiss: dismissHandler, trigger: trigger, originalTitle: originalTitle, contentElement: contentElement, originalParent: originalParent, originalNextSibling: originalNextSibling };
 
             setTimeout(function () {
                 document.addEventListener("pointerdown", dismissHandler);
@@ -178,11 +179,11 @@ window.Bootstrap = {
 
             document.removeEventListener("pointerdown", active.dismiss);
 
-            // Move the content element back to its original parent before dispose
-            // so Blazor's DOM tree stays intact.
+            // Move the content element back to its exact original position before
+            // dispose so Blazor's DOM diffing isn't confused by reordering.
             if (active.contentElement && active.originalParent) {
                 active.contentElement.style.display = "none";
-                active.originalParent.appendChild(active.contentElement);
+                active.originalParent.insertBefore(active.contentElement, active.originalNextSibling);
             }
 
             active.popover.dispose();

--- a/src/Recollections.Blazor.UI/wwwroot/js/site.js
+++ b/src/Recollections.Blazor.UI/wwwroot/js/site.js
@@ -140,6 +140,9 @@ window.Bootstrap = {
                 trigger.removeAttribute("title");
             }
 
+            // Remember original parent so we can move the node back on hide.
+            var originalParent = contentElement.parentNode;
+
             // Show the content element (it starts hidden) and pass the live DOM node
             // so async updates (e.g. image loading via JS interop) are visible.
             contentElement.style.display = "";
@@ -158,35 +161,40 @@ window.Bootstrap = {
             var dismissHandler = function (e) {
                 var tip = popover.tip;
                 if (tip && !tip.contains(e.target) && !trigger.contains(e.target)) {
-                    document.removeEventListener("pointerdown", dismissHandler);
-                    contentElement.style.display = "none";
-                    popover.dispose();
-                    if (originalTitle) {
-                        trigger.setAttribute("title", originalTitle);
-                    }
-                    Bootstrap.Popover._active = null;
+                    Bootstrap.Popover._disposeActive();
                 }
             };
 
-            Bootstrap.Popover._active = { popover: popover, dismiss: dismissHandler, trigger: trigger, originalTitle: originalTitle, contentElement: contentElement };
+            Bootstrap.Popover._active = { popover: popover, dismiss: dismissHandler, trigger: trigger, originalTitle: originalTitle, contentElement: contentElement, originalParent: originalParent };
 
             setTimeout(function () {
                 document.addEventListener("pointerdown", dismissHandler);
             }, 0);
         },
         _active: null,
-        _hideActive: function () {
-            if (Bootstrap.Popover._active) {
-                document.removeEventListener("pointerdown", Bootstrap.Popover._active.dismiss);
-                if (Bootstrap.Popover._active.contentElement) {
-                    Bootstrap.Popover._active.contentElement.style.display = "none";
-                }
-                Bootstrap.Popover._active.popover.dispose();
-                if (Bootstrap.Popover._active.originalTitle) {
-                    Bootstrap.Popover._active.trigger.setAttribute("title", Bootstrap.Popover._active.originalTitle);
-                }
-                Bootstrap.Popover._active = null;
+        _disposeActive: function () {
+            var active = Bootstrap.Popover._active;
+            if (!active) return;
+
+            document.removeEventListener("pointerdown", active.dismiss);
+
+            // Move the content element back to its original parent before dispose
+            // so Blazor's DOM tree stays intact.
+            if (active.contentElement && active.originalParent) {
+                active.contentElement.style.display = "none";
+                active.originalParent.appendChild(active.contentElement);
             }
+
+            active.popover.dispose();
+
+            if (active.originalTitle) {
+                active.trigger.setAttribute("title", active.originalTitle);
+            }
+
+            Bootstrap.Popover._active = null;
+        },
+        _hideActive: function () {
+            Bootstrap.Popover._disposeActive();
         },
         Dispose: function (container) {
             var popover = bootstrap.Popover.getInstance(container);

--- a/src/Recollections.Blazor.UI/wwwroot/js/site.js
+++ b/src/Recollections.Blazor.UI/wwwroot/js/site.js
@@ -481,6 +481,11 @@ window.ImageSource = {
             return status;
         }
 
+        if (!element) {
+            URL.revokeObjectURL(objectUrl);
+            return 0;
+        }
+
         return await new Promise(resolve => {
             const tag = element.tagName ? element.tagName.toLowerCase() : "";
             const loadEvent = tag === "video" ? "loadeddata" : "load";

--- a/src/Recollections.Blazor.UI/wwwroot/js/site.js
+++ b/src/Recollections.Blazor.UI/wwwroot/js/site.js
@@ -138,10 +138,14 @@ window.Bootstrap = {
                 trigger.removeAttribute("title");
             }
 
+            // Show the content element (it starts hidden) and pass the live DOM node
+            // so async updates (e.g. image loading via JS interop) are visible.
+            contentElement.style.display = "";
+
             var popover = new bootstrap.Popover(trigger, {
                 html: true,
                 sanitize: false,
-                content: contentElement.innerHTML,
+                content: contentElement,
                 placement: "top",
                 trigger: "manual",
                 customClass: "entry-popover"
@@ -153,6 +157,7 @@ window.Bootstrap = {
                 var tip = popover.tip;
                 if (tip && !tip.contains(e.target) && !trigger.contains(e.target)) {
                     document.removeEventListener("pointerdown", dismissHandler);
+                    contentElement.style.display = "none";
                     popover.dispose();
                     if (originalTitle) {
                         trigger.setAttribute("title", originalTitle);
@@ -161,7 +166,7 @@ window.Bootstrap = {
                 }
             };
 
-            Bootstrap.Popover._active = { popover: popover, dismiss: dismissHandler, trigger: trigger, originalTitle: originalTitle };
+            Bootstrap.Popover._active = { popover: popover, dismiss: dismissHandler, trigger: trigger, originalTitle: originalTitle, contentElement: contentElement };
 
             setTimeout(function () {
                 document.addEventListener("pointerdown", dismissHandler);
@@ -171,6 +176,9 @@ window.Bootstrap = {
         _hideActive: function () {
             if (Bootstrap.Popover._active) {
                 document.removeEventListener("pointerdown", Bootstrap.Popover._active.dismiss);
+                if (Bootstrap.Popover._active.contentElement) {
+                    Bootstrap.Popover._active.contentElement.style.display = "none";
+                }
                 Bootstrap.Popover._active.popover.dispose();
                 if (Bootstrap.Popover._active.originalTitle) {
                     Bootstrap.Popover._active.trigger.setAttribute("title", Bootstrap.Popover._active.originalTitle);

--- a/src/Recollections.Blazor.UI/wwwroot/js/site.js
+++ b/src/Recollections.Blazor.UI/wwwroot/js/site.js
@@ -133,6 +133,8 @@ window.Bootstrap = {
         ShowFromElement: function (trigger, contentElement) {
             Bootstrap.Popover._hideActive();
 
+            if (!contentElement) return;
+
             var originalTitle = trigger.getAttribute("title");
             if (originalTitle) {
                 trigger.removeAttribute("title");


### PR DESCRIPTION
On the entry detail map, clicking an image or video marker previously navigated directly to the media detail page. This made it easy to accidentally leave the entry when exploring marker locations.

This change adds a popover card (matching the pattern already used for entry-backed markers on the Map page, Story detail, etc.) that shows a thumbnail, name, and date. Clicking the card still navigates to the full detail page, giving users a preview before committing to navigation.

**Approach:**

- `MediaCardPopover.razor` -- new popover component displaying image/video thumbnail and metadata, linked to the detail page
- `MediaPopoverHandler.cs` -- state handler managing popover lifecycle (parallels the existing `MapPopoverHandler`/`EntryCardPopover` pattern)
- `EntryDetail.razor` / `.razor.cs` -- wires up the new popover; the Map component API is unchanged (`MarkerSelected` still fires with an index)