### PR TITLE
Fix upload cache crash for filenames with diacritics

### DIFF
--- a/src/Recollections.Blazor.Components/wwwroot/FileUpload.js
+++ b/src/Recollections.Blazor.Components/wwwroot/FileUpload.js
@@ -1,4 +1,22 @@
 ﻿// Sync with share-target.js (1:1)
+const FILE_NAME_HEADER_PREFIX = 'u:';
+
+function serializeFileNameHeaderValue(fileName) {
+    return `${FILE_NAME_HEADER_PREFIX}${encodeURIComponent(fileName || '')}`;
+}
+
+function deserializeFileNameHeaderValue(headerValue) {
+    if (!headerValue) {
+        return '';
+    }
+
+    if (!headerValue.startsWith(FILE_NAME_HEADER_PREFIX)) {
+        return headerValue;
+    }
+
+    return decodeURIComponent(headerValue.substring(FILE_NAME_HEADER_PREFIX.length));
+}
+
 async function storeFiles(files, actionUrl, entityType, entityId, userId) {
     const mediaCache = await caches.open('media');
     
@@ -13,7 +31,7 @@ async function storeFiles(files, actionUrl, entityType, entityId, userId) {
                     'X-User-Id': userId || '',
                     'X-Action-Url': actionUrl || '',
 
-                    'X-File-Name': file.name,
+                    'X-File-Name': serializeFileNameHeaderValue(file.name),
                     'X-Last-Modified': file.lastModified,
                     'Content-Size': file.size,
                     'Content-Type': file.type,
@@ -56,7 +74,7 @@ async function getStoredFilesByFlag(assigned) {
 
         if (isPassed) {
             const file = await response.blob();
-            file.name = response.headers.get('X-File-Name');
+            file.name = deserializeFileNameHeaderValue(response.headers.get('X-File-Name'));
             file.lastModified = Number.parseInt(response.headers.get('X-Last-Modified'));
             
             const storedFile = {

--- a/src/Recollections.Blazor.Components/wwwroot/FileUpload.js
+++ b/src/Recollections.Blazor.Components/wwwroot/FileUpload.js
@@ -14,7 +14,12 @@ function deserializeFileNameHeaderValue(headerValue) {
         return headerValue;
     }
 
-    return decodeURIComponent(headerValue.substring(FILE_NAME_HEADER_PREFIX.length));
+    const encodedFileName = headerValue.substring(FILE_NAME_HEADER_PREFIX.length);
+    try {
+        return decodeURIComponent(encodedFileName);
+    } catch {
+        return encodedFileName;
+    }
 }
 
 async function storeFiles(files, actionUrl, entityType, entityId, userId) {

--- a/src/Recollections.Blazor.UI/wwwroot/share-target.js
+++ b/src/Recollections.Blazor.UI/wwwroot/share-target.js
@@ -32,6 +32,12 @@ async function findExistingClient(event) {
         || null;
 }
 
+const FILE_NAME_HEADER_PREFIX = 'u:';
+
+function serializeFileNameHeaderValue(fileName) {
+    return `${FILE_NAME_HEADER_PREFIX}${encodeURIComponent(fileName || '')}`;
+}
+
 // Sync with FileUpload.js (1:1)
 async function storeFiles(files, actionUrl, entityType, entityId, userId) {
     const mediaCache = await caches.open('media');
@@ -47,7 +53,7 @@ async function storeFiles(files, actionUrl, entityType, entityId, userId) {
                     'X-User-Id': userId || '',
                     'X-Action-Url': actionUrl || '',
 
-                    'X-File-Name': file.name,
+                    'X-File-Name': serializeFileNameHeaderValue(file.name),
                     'X-Last-Modified': file.lastModified,
                     'Content-Size': file.size,
                     'Content-Type': file.type,


### PR DESCRIPTION
Uploading files with diacritics in the filename (for example `š`) failed in the browser because `Response` header values must be ISO-8859-1 compatible. This broke the cached upload flow before the request was sent.

This change makes cached filename metadata header-safe by encoding `X-File-Name` before storing it in the cache and decoding it when files are read back. To avoid breaking existing cached entries, read logic remains backward compatible: values without the new prefix are treated as legacy and used as-is.

The same serialization logic is applied to both upload storage paths (`FileUpload.js` and `share-target.js`) so their intended 1:1 behavior stays aligned.

Fixes: #535