### PR TITLE
Show beings on On This Day cards

### DIFF
--- a/src/Recollections.Blazor.UI/Entries/Components/EntryBeingsInfo.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/EntryBeingsInfo.razor
@@ -1,4 +1,4 @@
-@if (Beings.Count > 0)
+@if (Beings is { Count: > 0 })
 {
     foreach (var being in Beings)
     {

--- a/src/Recollections.Blazor.UI/Entries/Components/EntryBeingsInfo.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/EntryBeingsInfo.razor
@@ -1,0 +1,28 @@
+@if (Beings.Count > 0)
+{
+    foreach (var being in Beings)
+    {
+        if (Inline)
+        {
+            <span class="information">
+                <BeingIcon Identifier="@being.Icon" />
+                @being.Name
+            </span>
+        }
+        else
+        {
+            <div class="information">
+                <BeingIcon Identifier="@being.Icon" />
+                @being.Name
+            </div>
+        }
+    }
+}
+
+@code {
+    [Parameter]
+    public List<EntryBeingModel> Beings { get; set; } = [];
+
+    [Parameter]
+    public bool Inline { get; set; } = true;
+}

--- a/src/Recollections.Blazor.UI/Entries/Components/EntryCard.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/EntryCard.razor
@@ -62,7 +62,9 @@
                     @Model.VideoCount
                 </div>
             }
-
+ 
+            <EntryBeingsInfo Beings="Model.Beings" Inline="false" />
+ 
             @if (UserState.UserId != Model.UserId)
             {
                 <div class="information">

--- a/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor
+++ b/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor
@@ -96,16 +96,7 @@
                                 </span>
                             }
 
-                            @if (entry.Beings != null)
-                            {
-                                foreach (var being in entry.Beings)
-                                {
-                                    <span class="information">
-                                        <BeingIcon Identifier="@being.Icon" />
-                                        @being.Name
-                                    </span>
-                                }
-                            }
+                            <EntryBeingsInfo Beings="entry.Beings" />
 
                             @if (UserState.UserId != entry.UserId)
                             {


### PR DESCRIPTION
On the `On this day` page, entry cards were not showing attached beings even though the API already returned them. This made the cards inconsistent with timeline rendering and hid useful context.

This change adds a small shared `EntryBeingsInfo` component to render entry beings (`BeingIcon` + name), then reuses it in both `EntryCard` and `Timeline`.

Using the shared component keeps the behavior consistent across views and removes duplicated beings markup from timeline rendering.

Fixes: #542