### PR TITLE
Fix missing video size text in timeline gallery

### DIFF
--- a/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Components/Timeline.razor.cs
@@ -265,33 +265,7 @@ namespace Neptuo.Recollections.Entries.Components
         private void UpdateGalleryItems(IEnumerable<MediaModel> media)
         {
             GalleryItems.Clear();
-            foreach (MediaModel item in media)
-            {
-                if (item.Image != null)
-                {
-                    GalleryItems.Add(new GalleryModel
-                    {
-                        Type = "image",
-                        Title = item.Image.Name,
-                        Width = item.Image.Preview.Width,
-                        Height = item.Image.Preview.Height,
-                        PreviewUrl = Api.GetMediaUrl(item.Image.Preview.Url),
-                    });
-                }
-                else if (item.Video != null)
-                {
-                    GalleryItems.Add(new GalleryModel
-                    {
-                        Type = "video",
-                        Title = item.Video.Name,
-                        Width = item.Video.Preview.Width,
-                        Height = item.Video.Preview.Height,
-                        ContentType = item.Video.ContentType,
-                        PreviewUrl = Api.GetMediaUrl(item.Video.Preview.Url),
-                        OriginalUrl = Api.GetMediaUrl(item.Video.Original.Url),
-                    });
-                }
-            }
+            GalleryModelMapper.AddMapped(GalleryItems, media, Api);
         }
 
         protected async Task OnGalleryOpenInfoAsync(int index)

--- a/src/Recollections.Blazor.UI/Entries/GalleryModelMapper.cs
+++ b/src/Recollections.Blazor.UI/Entries/GalleryModelMapper.cs
@@ -1,0 +1,57 @@
+using Neptuo.Recollections.Components;
+using System.Collections.Generic;
+
+namespace Neptuo.Recollections.Entries;
+
+internal static class GalleryModelMapper
+{
+    public static void AddMapped(ICollection<GalleryModel> target, IEnumerable<MediaModel> media, Api api)
+    {
+        Ensure.NotNull(target, nameof(target));
+        Ensure.NotNull(media, nameof(media));
+        Ensure.NotNull(api, nameof(api));
+
+        foreach (MediaModel item in media)
+        {
+            if (TryMap(item, api, out GalleryModel model))
+                target.Add(model);
+        }
+    }
+
+    public static bool TryMap(MediaModel item, Api api, out GalleryModel model)
+    {
+        Ensure.NotNull(api, nameof(api));
+
+        if (item?.Image != null)
+        {
+            model = new GalleryModel
+            {
+                Type = "image",
+                Title = item.Image.Name,
+                Width = item.Image.Preview.Width,
+                Height = item.Image.Preview.Height,
+                PreviewUrl = api.GetMediaUrl(item.Image.Preview.Url),
+            };
+            return true;
+        }
+
+        if (item?.Video != null)
+        {
+            model = new GalleryModel
+            {
+                Type = "video",
+                Title = item.Video.Name,
+                SizeText = Utils.FileSizeText(item.Video.OriginalSize),
+                Width = item.Video.Preview.Width,
+                Height = item.Video.Preview.Height,
+                ContentType = item.Video.ContentType,
+                PreviewUrl = api.GetMediaUrl(item.Video.Preview.Url),
+                OriginalUrl = api.GetMediaUrl(item.Video.Original.Url),
+            };
+            return true;
+        }
+
+        model = null;
+        return false;
+    }
+}

--- a/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Pages/EntryDetail.razor.cs
@@ -230,34 +230,7 @@ namespace Neptuo.Recollections.Entries.Pages
             }
 
             GalleryItems.Clear();
-            foreach (var item in Media)
-            {
-                if (item.Image != null)
-                {
-                    GalleryItems.Add(new GalleryModel()
-                    {
-                        Type = "image",
-                        Title = item.Image.Name,
-                        Width = item.Image.Preview.Width,
-                        Height = item.Image.Preview.Height,
-                        PreviewUrl = Api.GetMediaUrl(item.Image.Preview.Url),
-                    });
-                }
-                else if (item.Video != null)
-                {
-                    GalleryItems.Add(new GalleryModel()
-                    {
-                        Type = "video",
-                        Title = item.Video.Name,
-                        SizeText = Utils.FileSizeText(item.Video.OriginalSize),
-                        Width = item.Video.Preview.Width,
-                        Height = item.Video.Preview.Height,
-                        ContentType = item.Video.ContentType,
-                        PreviewUrl = Api.GetMediaUrl(item.Video.Preview.Url),
-                        OriginalUrl = Api.GetMediaUrl(item.Video.Original.Url),
-                    });
-                }
-            }
+            GalleryModelMapper.AddMapped(GalleryItems, Media, Api);
         }
 
         private async Task OnGalleryOpenInfoAsync(int index)

--- a/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor.cs
+++ b/src/Recollections.Blazor.UI/Entries/Pages/StoryDetail.razor.cs
@@ -111,31 +111,8 @@ namespace Neptuo.Recollections.Entries.Pages
                 foreach (var item in entry.Media)
                 {
                     AllMedia.Add(item);
-                    if (item.Image != null)
-                    {
-                        GalleryItems.Add(new GalleryModel()
-                        {
-                            Type = "image",
-                            Title = item.Image.Name,
-                            Width = item.Image.Preview.Width,
-                            Height = item.Image.Preview.Height,
-                            PreviewUrl = Api.GetMediaUrl(item.Image.Preview.Url),
-                        });
-                    }
-                    else if (item.Video != null)
-                    {
-                        GalleryItems.Add(new GalleryModel()
-                        {
-                            Type = "video",
-                            Title = item.Video.Name,
-                            SizeText = Utils.FileSizeText(item.Video.OriginalSize),
-                            Width = item.Video.Preview.Width,
-                            Height = item.Video.Preview.Height,
-                            ContentType = item.Video.ContentType,
-                            PreviewUrl = Api.GetMediaUrl(item.Video.Preview.Url),
-                            OriginalUrl = Api.GetMediaUrl(item.Video.Original.Url),
-                        });
-                    }
+                    if (GalleryModelMapper.TryMap(item, Api, out GalleryModel galleryModel))
+                        GalleryItems.Add(galleryModel);
                 }
             }
         }


### PR DESCRIPTION
Timeline gallery video captions did not include file size, while entry and story galleries did. This made timeline behavior inconsistent and hid useful metadata.

This change centralizes `MediaModel -> GalleryModel` mapping in a shared `GalleryModelMapper` and reuses it in timeline, entry detail, and story detail gallery builders. Videos now consistently carry `SizeText` from `OriginalSize` across all three surfaces, and the shared mapper reduces drift risk between pages.

Fixes: #519