### PR TITLE
Fix mobile file picker to allow video selection

### DIFF
--- a/src/Recollections.Blazor.Components/Components/FileUpload.razor
+++ b/src/Recollections.Blazor.Components/Components/FileUpload.razor
@@ -1,5 +1,5 @@
 ﻿<form @ref="FormElement" class="inline-form @CssClass @FormCssClass" action="@Url">
-    <input type="file" multiple="@IsMultiple" accept="@Accept" class="d-none" />
+    <input type="file" multiple="@IsMultiple" accept="@(Accept ?? "image/*,video/*")" class="d-none" />
     <button type="button" class="@ButtonCssClass" @onclick="OnClick">
         <Icon Identifier="image" />
         @Text


### PR DESCRIPTION
Mobile upload flow should allow selecting both photos and videos, but on phones the picker was not reliably showing video files when no explicit `accept` filter was set.

This updates the shared `FileUpload` component to default the file input filter to `image/*,video/*` whenever `Accept` is not provided. Existing explicit `Accept` values are preserved (for example GPX import), so this only changes generic media-upload picker behavior.

Fixes: #534