### PR TITLE
Fix NU1903 by pinning SQLitePCLRaw bundle

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
 	<PackageVersion Include="System.Runtime.Caching" Version="$(FrameworkPackageVersion)" />
 	<PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
 	<PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+	<PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
 
 	<!-- Actual dependencies -->
 	<PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />


### PR DESCRIPTION
## Why
Restore/build for the data projects reported NU1903 for `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (GHSA-2m69-gcr7-jv3q). This keeps CI and local builds clean while removing exposure to the vulnerable transitive SQLite native package.

## What changed
This pins `SQLitePCLRaw.bundle_e_sqlite3` to `3.0.3` in central package management (`Directory.Packages.props`). Because transitive pinning is enabled, the vulnerable transitive `SQLitePCLRaw.lib.e_sqlite3` is lifted to a non-vulnerable version through the bundle dependency chain.

## Notes
This is a targeted dependency fix only. No runtime code paths were changed.