### PR TITLE
Add release notes for v0.20.4

### DIFF
--- a/src/Recollections.Blazor.UI/wwwroot/release-notes.json
+++ b/src/Recollections.Blazor.UI/wwwroot/release-notes.json
@@ -1,5 +1,17 @@
 [
     {
+        "version": "0.20.4",
+        "milestone": 57,
+        "breakingChanges": [],
+        "newFeatures": [],
+        "bugFixes": [
+            "On this day cards now show related beings",
+            "Image upload now works with filenames containing diacritics",
+            "Phone file picker now allows selecting videos",
+            "Timeline gallery now shows video size"
+        ]
+    },
+    {
         "version": "0.20.3",
         "milestone": 56,
         "breakingChanges": [],


### PR DESCRIPTION
This updates the Blazor release notes with the latest user-facing changes delivered in milestone 57, so the in-app update screen reflects what users actually received.

## What changed
- Prepended a new `0.20.4` entry to `src/Recollections.Blazor.UI/wwwroot/release-notes.json`
- Added milestone `57`
- Captured the delivered fixes:
  - On this day cards now show related beings
  - Image upload now works with filenames containing diacritics
  - Phone file picker now allows selecting videos
  - Timeline gallery now shows video size
